### PR TITLE
chore: add .claude/rules/ scoped rules and CLAUDE.md compact instructions

### DIFF
--- a/.claude/rules/adapters.md
+++ b/.claude/rules/adapters.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "src/adapters/**"
+---
+
+# Adapters
+
+When working with adapter code:
+
+1. **Implements ports** — every adapter must implement a port interface from `src/ports/`. Never add public methods beyond the port contract.
+2. **Complexity adapter** — uses `@typescript-eslint/typescript-estree` to parse ASTs. Cyclomatic complexity counts: `IfStatement`, `ConditionalExpression`, `For*Statement`, `While*Statement`, `DoWhileStatement`, `CatchClause`, `LogicalExpression` (`&&`, `||`, `??`), `ChainExpression` (`?.`), and non-default `SwitchCase`.
+3. **Coverage adapter** — parses V8 and Istanbul/NYC JSON formats. Detects format automatically via `detect.ts`.
+4. **Keep CC low** — adapter methods tend toward high CC from AST traversal. Extract helper methods aggressively. Use `Set.has()` over `||` chains for type checks.
+5. **Reporter adapters** — implement `ReporterPort`. Available formats: text (default), JSON, markdown. Reporters must not import from domain or core.
+6. **Span conventions** — AST `loc.end.line` is inclusive; convert to exclusive (`+1`) when creating `SourceSpan` objects.

--- a/.claude/rules/cli.md
+++ b/.claude/rules/cli.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "src/cli/**"
+---
+
+# CLI
+
+When working with CLI code:
+
+1. **Thin shell** — the CLI is a thin wrapper over `core/analyze`. Business logic belongs in core or domain, not here.
+2. **Commander** — uses `commander` for argument parsing. Flags map to `AnalyzeOptions`.
+3. **Config discovery** — `config.ts` handles `crap4ts.config.ts` loading and merging with CLI flags. CLI flags take precedence.
+4. **Diff filtering** — `diff.ts` implements `--since` / `--diff` for analyzing only changed files. This filters the file list before passing to `analyze()`.
+5. **Environment variables** — `CRAP4TS_FORMAT`, `CRAP4TS_THRESHOLD`, `NO_COLOR` are supported. CLI flags override env vars.
+6. **Exit codes** — exit 0 when all functions pass threshold, exit 1 when any exceed it. Never exit non-zero for warnings.

--- a/.claude/rules/core.md
+++ b/.claude/rules/core.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "src/core/**"
+---
+
+# Core
+
+When working with core code:
+
+1. **Wiring layer** — core composes adapters through port interfaces. It should contain orchestration logic, not business rules.
+2. **Dependency injection** — `analyze()` and `analyzeFile()` accept an `AnalyzeDeps` parameter for testing. Production defaults are lazy-loaded from `defaults.ts`.
+3. **No direct adapter imports in analyze** — always go through ports. Direct adapter imports belong only in `defaults.ts`.
+4. **Shared helpers** — `extractCoveragePercent` and `flattenCoverages` are exported from `analyze.ts` for reuse by `analyze-file.ts`. `groupBy` comes from `domain/matching.ts`.
+5. **Option resolution** — `resolveOptions` binds `options ?? {}` early to avoid repeated optional chaining (reduces CC). Follow this pattern for new option-heavy functions.
+6. **Config loading** — `define-config.ts` provides the `defineConfig()` API for `crap4ts.config.ts` files.

--- a/.claude/rules/domain.md
+++ b/.claude/rules/domain.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "src/domain/**"
+---
+
+# Domain
+
+When working with domain code:
+
+1. **Purity** — no I/O, no Node APIs, no external packages. Domain code is pure logic only.
+2. **No inward imports** — domain imports nothing from ports, adapters, core, or cli.
+3. **Immutability** — prefer `ReadonlyArray` and `Readonly<T>` for function parameters. Never mutate inputs — copy before sorting or modifying.
+4. **Types live here** — all shared type definitions (`FunctionComplexity`, `CrapScore`, `SourceSpan`, etc.) are defined in `domain/types.ts`.
+5. **CRAP formula** — `CC^2 * (1 - coverage)^3 + CC`. Changes to the formula must update both `crap.ts` and its tests.
+6. **Half-open spans** — `SourceSpan` uses exclusive `endLine`. All span arithmetic must respect this convention.
+7. **Threshold config** — `threshold.ts` supports glob-based per-path overrides. Default threshold is 30, `--strict` is 8.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "tests/**"
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+---
+
+# Testing
+
+When working with tests:
+
+1. **TDD** — write tests before implementation for domain and adapter code. For refactoring, write characterization tests first to lock behavior.
+2. **Vitest** — test runner with v8 coverage. Run `npm run test` (all), `npx vitest run <path>` (single file).
+3. **Fixtures** — test fixtures live in `tests/fixtures/`. Each fixture is a real TypeScript file that exercises specific AST patterns.
+4. **Test helpers** — `analyzeFixture(name)` reads a fixture and extracts complexity. `createDeps()` builds injectable test dependencies.
+5. **No mocking adapters in integration tests** — use the real adapter with fixture files. Mock only I/O boundaries (`readFile`, `readJson`, `findFiles`).
+6. **Assert behavior, not implementation** — test `qualifiedName` and `cyclomaticComplexity` values, not internal AST traversal details.
+7. **Coverage metric** — run `npm run test:coverage` and verify with `node dist/cli.js --coverage coverage/coverage-final.json --src src --threshold 8`.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 reports/
 *.tsbuildinfo
 .DS_Store
+
+# Claude Code
+.claude/*
+!.claude/rules/
+!.claude/rules/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,28 @@ fix(domain):   test:         ci:              docs:        chore:
 - `vitest.config.ts` — Test configuration
 - `crap4ts.config.ts` — Local dev config (not committed by default)
 - `eslint.config.ts` — Flat ESLint config
+
+## Rule Maintenance
+
+Scoped rules live in `.claude/rules/` and load on-demand when matching files are touched.
+
+- When you discover a new pattern, convention, or risk specific to a layer (domain, adapters, core, cli, tests), update the relevant rule file.
+- When a rule becomes stale or contradicts current code, update or remove it.
+- Keep rules actionable and concise — each point should prevent a concrete mistake.
+
+## Compact Instructions
+
+During context compaction, preserve:
+
+- Architecture layer and dependency direction constraints
+- Current task context, plan progress, and blocking issues
+- File paths and line numbers actively being worked on
+- Test results and CRAP scores from the most recent verification run
+- Any user feedback or corrections given during the session
+
+During context compaction, discard:
+
+- Full file contents already committed (re-read from disk if needed)
+- Intermediate failed attempts that were superseded by working solutions
+- Verbose tool output that has already been summarized
+- Completed and merged PR details (check git log if needed)


### PR DESCRIPTION
## Summary

- Updated `.gitignore` to track `.claude/rules/` while ignoring other `.claude/` contents
- Created 5 scoped rules (`domain`, `adapters`, `core`, `cli`, `testing`) that load on-demand when matching files are touched
- Added **Rule Maintenance** and **Compact Instructions** sections to `CLAUDE.md`

Closes #8

## Test plan
- [x] Rules follow frontmatter format with `paths:` globs matching repo structure
- [x] `.gitignore` correctly tracks `.claude/rules/**` while ignoring `.claude/*`
- [x] No code changes — build/test/lint unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)