### PR TITLE
fix: flatten AnalysisResult and add accurate byte-to-line conversion (#3, #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ reports/
 .claude/*
 !.claude/rules/
 !.claude/rules/**
+.workflow/

--- a/src/adapters/coverage/istanbul.ts
+++ b/src/adapters/coverage/istanbul.ts
@@ -1,4 +1,4 @@
-import type { CoveragePort } from "../../ports/coverage-port.js";
+import type { CoveragePort, CoverageParseResult } from "../../ports/coverage-port.js";
 import type {
   FunctionCoverage,
   CoverageRatio,
@@ -153,7 +153,7 @@ export class IstanbulCoverageAdapter implements CoveragePort {
     this.cwd = cwd;
   }
 
-  parse(data: unknown): Map<string, FunctionCoverage[]> {
+  parse(data: unknown): CoverageParseResult {
     if (data === null || typeof data !== "object" || Array.isArray(data)) {
       throw new Error(
         "Invalid Istanbul coverage data: expected an object keyed by file paths",
@@ -219,6 +219,6 @@ export class IstanbulCoverageAdapter implements CoveragePort {
       result.set(relativePath, functions);
     }
 
-    return result;
+    return { coverage: result, warnings: [] };
   }
 }

--- a/src/adapters/coverage/v8.ts
+++ b/src/adapters/coverage/v8.ts
@@ -1,8 +1,9 @@
-import type { CoveragePort } from "../../ports/coverage-port.js";
+import type { CoveragePort, CoverageParseResult } from "../../ports/coverage-port.js";
 import type {
   FunctionCoverage,
   CoverageRatio,
   SourceSpan,
+  Warning,
 } from "../../domain/types.js";
 
 // ── V8 Coverage JSON types ────────────────────────────────────────
@@ -27,8 +28,52 @@ interface V8ScriptCoverage {
 
 // ── Constants ─────────────────────────────────────────────────────
 
-/** Approximate characters per line for byte-offset → line-number conversion. */
+/** Approximate characters per line for Tier 3 fallback. */
 const APPROX_CHARS_PER_LINE = 40;
+
+// ── Line Offset Table (Tier 2) ───────────────────────────────────
+
+/**
+ * Build a table of cumulative byte offsets for each line boundary.
+ * table[i] = byte offset of the start of line (i+1).
+ * table[0] = 0 (line 1 starts at byte 0).
+ */
+export function buildLineOffsetTable(source: string): number[] {
+  const table: number[] = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") {
+      table.push(i + 1);
+    }
+  }
+  return table;
+}
+
+/**
+ * Convert a byte offset to a 1-based line number using binary search
+ * on a line offset table.
+ */
+export function byteOffsetToLineFromTable(
+  offset: number,
+  table: readonly number[],
+): number {
+  let lo = 0;
+  let hi = table.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (table[mid]! <= offset) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo + 1; // 1-based
+}
+
+// ── Tier 3 Fallback ──────────────────────────────────────────────
+
+function byteOffsetToLineApprox(offset: number): number {
+  return Math.max(1, Math.ceil(offset / APPROX_CHARS_PER_LINE));
+}
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -97,23 +142,26 @@ function computeByteCoverage(ranges: readonly V8Range[]): CoverageRatio {
   return { covered: coveredBytes, total: totalBytes, percent };
 }
 
-function byteOffsetToLine(offset: number): number {
-  return Math.max(1, Math.ceil(offset / APPROX_CHARS_PER_LINE));
-}
+function computeSpan(
+  outerRange: V8Range,
+  table: readonly number[] | null,
+): SourceSpan {
+  if (table) {
+    const startLine = byteOffsetToLineFromTable(outerRange.startOffset, table);
+    const endLine = Math.max(
+      startLine + 1,
+      byteOffsetToLineFromTable(outerRange.endOffset, table) + 1,
+    );
+    return { startLine, startColumn: 0, endLine, endColumn: 0 };
+  }
 
-function computeApproximateSpan(outerRange: V8Range): SourceSpan {
-  const startLine = byteOffsetToLine(outerRange.startOffset);
+  // Tier 3: approximation
+  const startLine = byteOffsetToLineApprox(outerRange.startOffset);
   const endLine = Math.max(
     startLine + 1,
     Math.ceil(outerRange.endOffset / APPROX_CHARS_PER_LINE) + 1,
   );
-
-  return {
-    startLine,
-    startColumn: 0,
-    endLine, // exclusive, per domain convention
-    endColumn: 0,
-  };
+  return { startLine, startColumn: 0, endLine, endColumn: 0 };
 }
 
 // ── Adapter ───────────────────────────────────────────────────────
@@ -125,7 +173,10 @@ export class V8CoverageAdapter implements CoveragePort {
     this.cwd = cwd;
   }
 
-  parse(data: unknown): Map<string, FunctionCoverage[]> {
+  parse(
+    data: unknown,
+    sources?: ReadonlyMap<string, string>,
+  ): CoverageParseResult {
     if (data === null || typeof data !== "object" || Array.isArray(data)) {
       throw new Error(
         "Invalid V8 coverage data: expected an object with a 'result' array",
@@ -153,12 +204,33 @@ export class V8CoverageAdapter implements CoveragePort {
       : findLongestCommonPrefix(absolutePaths);
 
     const result = new Map<string, FunctionCoverage[]>();
+    const warnings: Warning[] = [];
+    const warnedFiles = new Set<string>();
 
     for (let i = 0; i < scripts.length; i++) {
       const script = scripts[i]!;
       const absolutePath = absolutePaths[i]!;
       const relativePath = normalizePath(absolutePath, prefix);
       const functions: FunctionCoverage[] = [];
+
+      // Try to get source content for accurate line mapping (Tier 2)
+      const sourceContent = sources?.get(relativePath) ?? null;
+      const lineTable = sourceContent
+        ? buildLineOffsetTable(sourceContent)
+        : null;
+
+      // Emit warning if falling back to approximation
+      if (!lineTable && !warnedFiles.has(relativePath)) {
+        const hasFunctions = script.functions.some((fn) => fn.functionName && fn.ranges.length > 0);
+        if (hasFunctions) {
+          warnings.push({
+            code: "approximate-span",
+            message: `Source content unavailable for "${relativePath}" — using approximate byte-to-line conversion`,
+            file: relativePath,
+          });
+          warnedFiles.add(relativePath);
+        }
+      }
 
       for (const fn of script.functions) {
         // Skip anonymous functions (empty name)
@@ -168,7 +240,7 @@ export class V8CoverageAdapter implements CoveragePort {
         if (fn.ranges.length === 0) continue;
 
         const outerRange = fn.ranges[0]!;
-        const span = computeApproximateSpan(outerRange);
+        const span = computeSpan(outerRange, lineTable);
         const lineCoverage = computeByteCoverage(fn.ranges);
 
         functions.push({
@@ -183,6 +255,6 @@ export class V8CoverageAdapter implements CoveragePort {
       result.set(relativePath, functions);
     }
 
-    return result;
+    return { coverage: result, warnings };
   }
 }

--- a/src/adapters/reporters/console.ts
+++ b/src/adapters/reporters/console.ts
@@ -1,6 +1,6 @@
 import { Chalk, type ChalkInstance } from "chalk";
 import type { ReporterPort } from "../../ports/reporter-port.js";
-import type { AnalysisResult, FunctionVerdict } from "../../domain/types.js";
+import type { AnalysisResult } from "../../domain/types.js";
 import { readPackageVersion } from "./version.js";
 
 export interface ConsoleReporterOptions {
@@ -25,17 +25,17 @@ export class ConsoleReporter implements ReporterPort {
     lines.push("");
 
     // ── Table ───────────────────────────────────────────────────────
-    const allVerdicts = this.collectVerdicts(result);
+    const verdicts = result.functions;
 
-    if (allVerdicts.length > 0) {
+    if (verdicts.length > 0) {
       // Column widths
       const fileW = Math.max(
         4,
-        ...allVerdicts.map((v) => v.scored.identity.filePath.length),
+        ...verdicts.map((v) => v.scored.identity.filePath.length),
       );
       const fnW = Math.max(
         8,
-        ...allVerdicts.map((v) => v.scored.identity.qualifiedName.length),
+        ...verdicts.map((v) => v.scored.identity.qualifiedName.length),
       );
       const ccW = 4;
       const covW = 6;
@@ -52,7 +52,7 @@ export class ConsoleReporter implements ReporterPort {
       );
 
       // Data rows
-      for (const v of allVerdicts) {
+      for (const v of verdicts) {
         const { scored, exceeds } = v;
         const filePath = scored.identity.filePath.padEnd(fileW);
         const fnName = scored.identity.qualifiedName.padEnd(fnW);
@@ -83,16 +83,6 @@ export class ConsoleReporter implements ReporterPort {
     lines.push("");
 
     return lines.join("\n");
-  }
-
-  private collectVerdicts(result: AnalysisResult): FunctionVerdict[] {
-    const verdicts: FunctionVerdict[] = [];
-    for (const file of result.files) {
-      for (const fn of file.functions) {
-        verdicts.push(fn);
-      }
-    }
-    return verdicts;
   }
 
   private colorizeCoverage(formatted: string, percent: number): string {

--- a/src/adapters/reporters/json.ts
+++ b/src/adapters/reporters/json.ts
@@ -10,7 +10,9 @@ export class JsonReporter implements ReporterPort {
       timestamp: new Date().toISOString(),
       config: result.thresholdConfig,
       summary: result.summary,
-      files: result.files,
+      functions: result.functions,
+      unmatched: result.unmatched,
+      warnings: result.warnings,
       passed: result.passed,
     };
 

--- a/src/adapters/reporters/markdown.ts
+++ b/src/adapters/reporters/markdown.ts
@@ -22,14 +22,12 @@ export class MarkdownReporter implements ReporterPort {
     lines.push("");
 
     // ── Collect and sort all verdicts ──────────────────────────────────
-    const allVerdicts = this.collectVerdicts(result);
-
-    if (allVerdicts.length === 0) {
+    if (result.functions.length === 0) {
       return lines.join("\n");
     }
 
     // Sort by CRAP score descending
-    const sorted = [...allVerdicts].sort(
+    const sorted = [...result.functions].sort(
       (a, b) => b.scored.crap.value - a.scored.crap.value,
     );
 
@@ -58,16 +56,6 @@ export class MarkdownReporter implements ReporterPort {
     }
 
     return lines.join("\n");
-  }
-
-  private collectVerdicts(result: AnalysisResult): FunctionVerdict[] {
-    const verdicts: FunctionVerdict[] = [];
-    for (const file of result.files) {
-      for (const fn of file.functions) {
-        verdicts.push(fn);
-      }
-    }
-    return verdicts;
   }
 
   private appendTable(lines: string[], verdicts: FunctionVerdict[]): void {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -21,7 +21,6 @@ import { ConsoleReporter } from "../adapters/reporters/console.js";
 import { JsonReporter } from "../adapters/reporters/json.js";
 import { MarkdownReporter } from "../adapters/reporters/markdown.js";
 import type { ReporterPort } from "../ports/reporter-port.js";
-import { RiskLevel } from "../domain/types.js";
 import type { AnalysisResult, FunctionVerdict } from "../domain/types.js";
 
 // ── Exit Codes ─────────────────────────────────────────────────────
@@ -247,6 +246,15 @@ program.action(async (opts: Record<string, unknown>) => {
       console.log(output);
     }
 
+    // 9b. Show warnings on stderr when --verbose
+    if (verbose && result.warnings.length > 0) {
+      console.error("");
+      console.error(`Warnings (${result.warnings.length}):`);
+      for (const w of result.warnings) {
+        console.error(`  [${w.code}] ${w.message}`);
+      }
+    }
+
     // 10. Exit with appropriate code
     process.exit(result.passed ? EXIT_OK : EXIT_THRESHOLD);
   } catch (err) {
@@ -325,35 +333,24 @@ function applyFilters(
   sortField?: string,
   topN?: number,
 ): AnalysisResult {
-  // Collect all verdicts
-  let allVerdicts: FunctionVerdict[] = [];
-  for (const file of result.files) {
-    for (const fn of file.functions) {
-      allVerdicts.push(fn);
-    }
-  }
+  const hasSort = Boolean(sortField);
+  const hasTopN = topN !== undefined && topN > 0;
 
-  // Sort
-  if (sortField) {
-    allVerdicts = sortVerdicts(allVerdicts, sortField);
-  }
-
-  // Top N
-  if (topN !== undefined && topN > 0) {
-    // Default to sorting by CRAP descending if no explicit sort
-    if (!sortField) {
-      allVerdicts = sortVerdicts(allVerdicts, "crap");
-    }
-    allVerdicts = allVerdicts.slice(0, topN);
-  }
-
-  if (!sortField && (topN === undefined || topN <= 0)) {
-    // No filtering needed — return original result
+  if (!hasSort && !hasTopN) {
     return result;
   }
 
-  // Rebuild the result with filtered verdicts grouped by file
-  return rebuildResult(result, allVerdicts);
+  // Default to sorting by CRAP descending when using --top without --sort
+  const effectiveSort = sortField ?? (hasTopN ? "crap" : undefined);
+  let verdicts = effectiveSort
+    ? sortVerdicts([...result.functions], effectiveSort)
+    : [...result.functions];
+
+  if (hasTopN) {
+    verdicts = verdicts.slice(0, topN);
+  }
+
+  return { ...result, functions: verdicts };
 }
 
 function sortVerdicts(
@@ -388,51 +385,6 @@ function sortVerdicts(
   }
 
   return sorted;
-}
-
-function rebuildResult(
-  original: AnalysisResult,
-  filteredVerdicts: FunctionVerdict[],
-): AnalysisResult {
-  // Group filtered verdicts by file
-  const byFile = new Map<string, FunctionVerdict[]>();
-  for (const v of filteredVerdicts) {
-    const file = v.scored.identity.filePath;
-    let group = byFile.get(file);
-    if (!group) {
-      group = [];
-      byFile.set(file, group);
-    }
-    group.push(v);
-  }
-
-  // Rebuild file results preserving only the filtered verdicts
-  const files = [...byFile.entries()].map(([filePath, verdicts]) => {
-    const originalFile = original.files.find(
-      (f) => f.filePath === filePath,
-    );
-    return {
-      filePath,
-      functions: verdicts,
-      unmatched: originalFile?.unmatched ?? [],
-      summary: originalFile?.summary ?? {
-        totalFunctions: verdicts.length,
-        exceedingThreshold: verdicts.filter((v) => v.exceeds).length,
-        maxCrap: verdicts[0]?.scored.crap ?? {
-          value: 0,
-          riskLevel: RiskLevel.Low,
-        },
-        averageCrap: 0,
-      },
-    };
-  });
-
-  return {
-    files,
-    summary: original.summary,
-    thresholdConfig: original.thresholdConfig,
-    passed: original.passed,
-  };
 }
 
 // ── Summary Formatting ─────────────────────────────────────────────

--- a/src/core/analyze-file.ts
+++ b/src/core/analyze-file.ts
@@ -8,6 +8,7 @@ import type {
   FunctionComplexity,
   FunctionCoverage,
   FunctionVerdict,
+  Warning,
   ThresholdConfig,
 } from "../domain/types.js";
 import { extractCoveragePercent, flattenCoverages } from "./analyze.js";
@@ -19,6 +20,11 @@ export interface AnalyzeFileOptions {
   coverage?: string;
   threshold?: number;
   coverageMetric?: "line" | "branch";
+}
+
+export interface AnalyzeFileResult {
+  readonly verdicts: ReadonlyArray<FunctionVerdict>;
+  readonly warnings: ReadonlyArray<Warning>;
 }
 
 /**
@@ -33,7 +39,7 @@ export async function analyzeFile(
   filePath: string,
   options?: AnalyzeFileOptions,
   deps?: AnalyzeDeps,
-): Promise<FunctionVerdict[]> {
+): Promise<AnalyzeFileResult> {
   const resolvedDeps = deps ?? (await loadDefaults());
   const opts = options ?? {};
   const coverageMetric = opts.coverageMetric ?? "line";
@@ -41,10 +47,14 @@ export async function analyzeFile(
 
   const source = await resolvedDeps.readFile(filePath);
   const complexities = resolvedDeps.complexityPort.extract(source, filePath);
-  if (complexities.length === 0) return [];
+  if (complexities.length === 0) return { verdicts: [], warnings: [] };
 
-  const allCoverages = await loadFileCoverages(resolvedDeps, opts.coverage);
-  const matchResult = resolvedDeps.matcher(complexities, allCoverages);
+  // Pass source content for accurate line mapping (Tier 2)
+  const sourceContents = new Map([[filePath, source]]);
+  const { coverages, warnings: coverageWarnings } =
+    await loadFileCoverages(resolvedDeps, opts.coverage, sourceContents);
+
+  const matchResult = resolvedDeps.matcher(complexities, coverages);
 
   const verdicts: FunctionVerdict[] = matchResult.matched.map(({ complexity, coverage }) =>
     scoreMatchedFunction(complexity, coverage, coverageMetric, thresholdConfig, resolvedDeps.globMatcher),
@@ -54,7 +64,7 @@ export async function analyzeFile(
     verdicts.push(scoreUnmatchedFunction(complexity, thresholdConfig, resolvedDeps.globMatcher));
   }
 
-  return verdicts;
+  return { verdicts, warnings: coverageWarnings };
 }
 
 // ── Internal Helpers ──────────────────────────────────────────────
@@ -105,11 +115,12 @@ function scoreUnmatchedFunction(
 async function loadFileCoverages(
   deps: AnalyzeDeps,
   coveragePath?: string,
-): Promise<FunctionCoverage[]> {
-  if (!coveragePath) return [];
+  sources?: ReadonlyMap<string, string>,
+): Promise<{ coverages: FunctionCoverage[]; warnings: Warning[] }> {
+  if (!coveragePath) return { coverages: [], warnings: [] };
   const rawData = await deps.readJson(coveragePath);
-  const coverageMap = deps.coveragePort.parse(rawData);
-  return flattenCoverages(coverageMap);
+  const { coverage, warnings } = deps.coveragePort.parse(rawData, sources);
+  return { coverages: flattenCoverages(coverage), warnings: [...warnings] };
 }
 
 async function loadDefaults(): Promise<AnalyzeDeps> {

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -4,23 +4,18 @@ import {
   createThresholdConfig,
   resolveThreshold,
 } from "../domain/threshold.js";
-import { groupBy } from "../domain/matching.js";
 import { computeSummary } from "../domain/summary.js";
-import {
-  RiskLevel,
-} from "../domain/types.js";
 import type {
   AnalyzeOptions,
   AnalysisResult,
   FunctionVerdict,
-  FileResult,
   UnmatchedFunction,
+  Warning,
   FunctionComplexity,
   FunctionCoverage,
   MatchFunctions,
   ThresholdConfig,
   ScoredFunction,
-  CrapScore,
 } from "../domain/types.js";
 import type { ComplexityPort } from "../ports/complexity-port.js";
 import type { CoveragePort } from "../ports/coverage-port.js";
@@ -63,20 +58,23 @@ export async function analyze(
     return emptyResult(thresholdConfig);
   }
 
-  // 3. Read coverage data
-  const coverageData = await loadCoverageData(resolvedDeps, opts.coveragePath);
-
-  // 4. Extract complexity for each source file
+  // 3. Read source files (used for both complexity extraction and accurate coverage mapping)
+  const sourceContents = new Map<string, string>();
   const allComplexities: FunctionComplexity[] = [];
   for (const filePath of sourceFiles) {
     const absolutePath = resolve(opts.cwd, filePath);
     const source = await resolvedDeps.readFile(absolutePath);
+    sourceContents.set(filePath, source);
     const fileComplexities = resolvedDeps.complexityPort.extract(
       source,
       filePath,
     );
     allComplexities.push(...fileComplexities);
   }
+
+  // 4. Read coverage data (pass source content for accurate line mapping)
+  const { coverage: coverageData, warnings: coverageWarnings } =
+    await loadCoverageData(resolvedDeps, opts.coveragePath, sourceContents);
 
   // 5. Flatten all coverage data
   const allCoverages = flattenCoverages(coverageData);
@@ -129,8 +127,25 @@ export async function analyze(
     });
   }
 
-  // 10. Group by file
-  const files = buildFileResults(allVerdicts, allUnmatched);
+  // 10. Collect warnings from coverage parsing and unmatched
+  const warnings: Warning[] = [...coverageWarnings];
+  for (const u of allUnmatched) {
+    if (u.kind === "no-coverage") {
+      warnings.push({
+        code: "unmatched-no-coverage",
+        message: `No coverage data found for function "${u.complexity.identity.qualifiedName}"`,
+        file: u.complexity.identity.filePath,
+        function: u.complexity.identity.qualifiedName,
+      });
+    } else {
+      warnings.push({
+        code: "unmatched-no-ast",
+        message: `No AST match found for coverage entry "${u.coverage.name}"`,
+        file: u.coverage.filePath,
+        function: u.coverage.name,
+      });
+    }
+  }
 
   // 11. Compute overall summary
   const summary = computeSummary(allVerdicts);
@@ -138,7 +153,7 @@ export async function analyze(
   // 12. Determine pass/fail
   const passed = allVerdicts.every((v) => !v.exceeds);
 
-  return { files, summary, thresholdConfig, passed };
+  return { functions: allVerdicts, unmatched: allUnmatched, warnings, summary, thresholdConfig, passed };
 }
 
 // ── Internal Helpers ──────────────────────────────────────────────
@@ -206,23 +221,21 @@ function buildThresholdConfig(opts: ResolvedOptions): ThresholdConfig {
 async function loadCoverageData(
   deps: AnalyzeDeps,
   coveragePath: string | undefined,
-): Promise<Map<string, FunctionCoverage[]>> {
+  sources?: ReadonlyMap<string, string>,
+): Promise<{ coverage: ReadonlyMap<string, ReadonlyArray<FunctionCoverage>>; warnings: Warning[] }> {
   if (!coveragePath) {
-    return new Map();
+    return { coverage: new Map(), warnings: [] };
   }
 
   const rawData = await deps.readJson(coveragePath);
-  return deps.coveragePort.parse(rawData);
+  const result = deps.coveragePort.parse(rawData, sources);
+  return { coverage: result.coverage, warnings: [...result.warnings] };
 }
 
 export function flattenCoverages(
-  coverageData: Map<string, FunctionCoverage[]>,
+  coverageData: ReadonlyMap<string, ReadonlyArray<FunctionCoverage>>,
 ): FunctionCoverage[] {
-  const result: FunctionCoverage[] = [];
-  for (const coverages of coverageData.values()) {
-    result.push(...coverages);
-  }
-  return result;
+  return Array.from(coverageData.values()).flat();
 }
 
 export function extractCoveragePercent(
@@ -235,76 +248,11 @@ export function extractCoveragePercent(
   return coverage.lineCoverage.percent;
 }
 
-function getUnmatchedFilePath(u: UnmatchedFunction): string {
-  return u.kind === "no-coverage"
-    ? u.complexity.identity.filePath
-    : u.coverage.filePath;
-}
-
-function buildFileResults(
-  verdicts: FunctionVerdict[],
-  unmatched: UnmatchedFunction[],
-): FileResult[] {
-  const verdictsByFile = groupBy(verdicts, (v) => v.scored.identity.filePath);
-  const unmatchedByFile = groupBy(unmatched, getUnmatchedFilePath);
-
-  const allFiles = new Set([...verdictsByFile.keys(), ...unmatchedByFile.keys()]);
-
-  const results: FileResult[] = [];
-  for (const filePath of allFiles) {
-    const fileVerdicts = verdictsByFile.get(filePath) ?? [];
-    const fileUnmatched = unmatchedByFile.get(filePath) ?? [];
-    results.push(buildSingleFileResult(filePath, fileVerdicts, fileUnmatched));
-  }
-
-  return results;
-}
-
-function buildSingleFileResult(
-  filePath: string,
-  verdicts: FunctionVerdict[],
-  unmatched: UnmatchedFunction[],
-): FileResult {
-  const totalFunctions = verdicts.length;
-  const exceedingThreshold = verdicts.filter((v) => v.exceeds).length;
-
-  let maxCrap: CrapScore = { value: 0, riskLevel: RiskLevel.Low };
-  let averageCrap = 0;
-
-  if (totalFunctions > 0) {
-    const crapValues = verdicts.map((v) => v.scored.crap.value);
-    averageCrap =
-      Math.round(
-        (crapValues.reduce((sum, v) => sum + v, 0) / totalFunctions +
-          Number.EPSILON) *
-          100,
-      ) / 100;
-
-    let maxVal = 0;
-    for (const v of verdicts) {
-      if (v.scored.crap.value > maxVal) {
-        maxVal = v.scored.crap.value;
-        maxCrap = v.scored.crap;
-      }
-    }
-  }
-
-  return {
-    filePath,
-    functions: verdicts,
-    unmatched,
-    summary: {
-      totalFunctions,
-      exceedingThreshold,
-      maxCrap,
-      averageCrap,
-    },
-  };
-}
-
 function emptyResult(thresholdConfig: ThresholdConfig): AnalysisResult {
   return {
-    files: [],
+    functions: [],
+    unmatched: [],
+    warnings: [],
     summary: computeSummary([]),
     thresholdConfig,
     passed: true,

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -7,7 +7,7 @@ import picomatch from "picomatch";
 import { readFile, readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
 import type { AnalyzeDeps } from "./analyze.js";
-import type { CoveragePort } from "../ports/coverage-port.js";
+import type { CoveragePort, CoverageParseResult } from "../ports/coverage-port.js";
 
 // ── Auto-Detecting Coverage Port ──────────────────────────────────
 
@@ -20,13 +20,13 @@ class AutoDetectCoverageAdapter implements CoveragePort {
     this.v8 = new V8CoverageAdapter(cwd);
   }
 
-  parse(data: unknown) {
+  parse(data: unknown, sources?: ReadonlyMap<string, string>): CoverageParseResult {
     const format = detectCoverageFormat(data);
     switch (format) {
       case "istanbul":
         return this.istanbul.parse(data);
       case "v8":
-        return this.v8.parse(data);
+        return this.v8.parse(data, sources);
       default:
         throw new Error(
           `Unknown coverage format. Expected Istanbul JSON or V8 format.`,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,7 @@
 export { analyze } from "./analyze.js";
 export type { AnalyzeDeps } from "./analyze.js";
 export { analyzeFile } from "./analyze-file.js";
-export type { AnalyzeFileOptions } from "./analyze-file.js";
+export type { AnalyzeFileOptions, AnalyzeFileResult } from "./analyze-file.js";
 export { defineConfig } from "./define-config.js";
 export type { Crap4tsConfig } from "./define-config.js";
 export { createDefaultDeps } from "./defaults.js";
@@ -11,7 +11,6 @@ export type {
   AnalyzeOptions,
   AnalysisResult,
   AnalysisSummary,
-  FileResult,
   FunctionVerdict,
   ScoredFunction,
   CrapScore,
@@ -23,5 +22,8 @@ export type {
   FunctionComplexity,
   FunctionCoverage,
   RiskDistribution,
+  UnmatchedFunction,
+  Warning,
+  WarningCode,
 } from "../domain/types.js";
 export { RiskLevel } from "../domain/types.js";

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -82,19 +82,22 @@ export type UnmatchedFunction =
       readonly coverage: FunctionCoverage;
     };
 
-// ── File & Analysis Results ─────────────────────────────────────────
+// ── Warnings ────────────────────────────────────────────────────────
 
-export interface FileResult {
-  readonly filePath: string;
-  readonly functions: ReadonlyArray<FunctionVerdict>;
-  readonly unmatched: ReadonlyArray<UnmatchedFunction>;
-  readonly summary: {
-    readonly totalFunctions: number;
-    readonly exceedingThreshold: number;
-    readonly maxCrap: CrapScore;
-    readonly averageCrap: number;
-  };
+export type WarningCode =
+  | "unmatched-no-coverage"
+  | "unmatched-no-ast"
+  | "approximate-span"
+  | "missing-coverage-file";
+
+export interface Warning {
+  readonly code: WarningCode;
+  readonly message: string;
+  readonly file?: string;
+  readonly function?: string;
 }
+
+// ── Analysis Results ────────────────────────────────────────────────
 
 export interface RiskDistribution {
   readonly [RiskLevel.Low]: number;
@@ -133,7 +136,9 @@ export type ThresholdPreset = "strict" | "default" | "lenient";
 // ── Top-Level Analysis Result ───────────────────────────────────────
 
 export interface AnalysisResult {
-  readonly files: ReadonlyArray<FileResult>;
+  readonly functions: ReadonlyArray<FunctionVerdict>;
+  readonly unmatched: ReadonlyArray<UnmatchedFunction>;
+  readonly warnings: ReadonlyArray<Warning>;
   readonly summary: AnalysisSummary;
   readonly thresholdConfig: ThresholdConfig;
   readonly passed: boolean;

--- a/src/ports/coverage-port.ts
+++ b/src/ports/coverage-port.ts
@@ -1,5 +1,13 @@
-import type { FunctionCoverage } from "../domain/types.js";
+import type { FunctionCoverage, Warning } from "../domain/types.js";
+
+export interface CoverageParseResult {
+  readonly coverage: ReadonlyMap<string, ReadonlyArray<FunctionCoverage>>;
+  readonly warnings: ReadonlyArray<Warning>;
+}
 
 export interface CoveragePort {
-  parse(data: unknown): Map<string, FunctionCoverage[]>;
+  parse(
+    data: unknown,
+    sources?: ReadonlyMap<string, string>,
+  ): CoverageParseResult;
 }

--- a/tests/adapters/coverage/istanbul.test.ts
+++ b/tests/adapters/coverage/istanbul.test.ts
@@ -13,7 +13,7 @@ describe("IstanbulCoverageAdapter", () => {
 
   describe("parse()", () => {
     it("returns a Map keyed by project-relative forward-slash paths", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       expect(result).toBeInstanceOf(Map);
       expect([...result.keys()]).toEqual(
         expect.arrayContaining(["src/math.ts", "src/utils/format.ts"]),
@@ -21,7 +21,7 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("groups functions by file", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       expect(result.get("src/math.ts")).toHaveLength(3);
       expect(result.get("src/utils/format.ts")).toHaveLength(1);
     });
@@ -29,13 +29,13 @@ describe("IstanbulCoverageAdapter", () => {
 
   describe("fnMap → FunctionCoverage[]", () => {
     it("extracts function names from fnMap", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const names = result.get("src/math.ts")!.map((f) => f.name);
       expect(names).toEqual(["add", "divide", "neverCalled"]);
     });
 
     it("converts inclusive endLine to exclusive (domainEndLine = sourceEndLine + 1)", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const add = result.get("src/math.ts")!.find((f) => f.name === "add")!;
       // source loc.end.line = 3 → domain endLine = 4
       expect(add.span.endLine).toBe(4);
@@ -43,7 +43,7 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("sets filePath to project-relative forward-slash path", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const fns = result.get("src/math.ts")!;
       for (const fn of fns) {
         expect(fn.filePath).toBe("src/math.ts");
@@ -53,7 +53,7 @@ describe("IstanbulCoverageAdapter", () => {
 
   describe("line coverage (statementMap + s)", () => {
     it("computes 100% line coverage for fully-covered function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const add = result.get("src/math.ts")!.find((f) => f.name === "add")!;
       // statement 0 (line 2) is within add (lines 1–3), s["0"] = 10
       expect(add.lineCoverage).toEqual({
@@ -64,7 +64,7 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("computes correct line coverage for partially-covered function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const divide = result
         .get("src/math.ts")!
         .find((f) => f.name === "divide")!;
@@ -78,7 +78,7 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("computes 0% line coverage for uncovered function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const neverCalled = result
         .get("src/math.ts")!
         .find((f) => f.name === "neverCalled")!;
@@ -93,7 +93,7 @@ describe("IstanbulCoverageAdapter", () => {
 
   describe("branch coverage (branchMap + b)", () => {
     it("computes branch coverage for function with if-branch", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const divide = result
         .get("src/math.ts")!
         .find((f) => f.name === "divide")!;
@@ -107,13 +107,13 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("returns null branchCoverage when function has no branches", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const add = result.get("src/math.ts")!.find((f) => f.name === "add")!;
       expect(add.branchCoverage).toBeNull();
     });
 
     it("returns null branchCoverage for file with no branches at all", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const formatName = result
         .get("src/utils/format.ts")!
         .find((f) => f.name === "formatName")!;
@@ -123,7 +123,7 @@ describe("IstanbulCoverageAdapter", () => {
 
   describe("path normalization", () => {
     it("strips cwd prefix and produces forward-slash paths", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const keys = [...result.keys()];
       for (const key of keys) {
         expect(key).not.toMatch(/^\//);
@@ -133,7 +133,7 @@ describe("IstanbulCoverageAdapter", () => {
 
     it("auto-detects common prefix when no cwd provided", () => {
       const autoAdapter = new IstanbulCoverageAdapter();
-      const result = autoAdapter.parse(loadFixture());
+      const result = autoAdapter.parse(loadFixture()).coverage;
       // Common prefix of /projects/my-app/src/math.ts and /projects/my-app/src/utils/format.ts
       // is /projects/my-app/src/ → relative paths are math.ts and utils/format.ts
       expect([...result.keys()]).toEqual(
@@ -150,7 +150,7 @@ describe("IstanbulCoverageAdapter", () => {
     });
 
     it("returns empty Map for empty object", () => {
-      const result = adapter.parse({});
+      const result = adapter.parse({}).coverage;
       expect(result.size).toBe(0);
     });
 
@@ -178,7 +178,7 @@ describe("IstanbulCoverageAdapter", () => {
           b: {},
         },
       };
-      const result = adapter.parse(data);
+      const result = adapter.parse(data).coverage;
       const noop = result.get("src/empty.ts")!.find((f) => f.name === "noop")!;
       expect(noop.lineCoverage).toEqual({
         covered: 0,
@@ -186,6 +186,13 @@ describe("IstanbulCoverageAdapter", () => {
         percent: 100,
       });
       expect(noop.branchCoverage).toBeNull();
+    });
+  });
+
+  describe("warnings", () => {
+    it("always returns empty warnings array", () => {
+      const { warnings } = adapter.parse(loadFixture());
+      expect(warnings).toEqual([]);
     });
   });
 });

--- a/tests/adapters/coverage/v8.test.ts
+++ b/tests/adapters/coverage/v8.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { V8CoverageAdapter } from "../../../src/adapters/coverage/v8.js";
+import {
+  V8CoverageAdapter,
+  buildLineOffsetTable,
+  byteOffsetToLineFromTable,
+} from "../../../src/adapters/coverage/v8.js";
 
 function loadFixture(): unknown {
   return JSON.parse(
@@ -13,7 +17,7 @@ describe("V8CoverageAdapter", () => {
 
   describe("parse()", () => {
     it("returns a Map keyed by project-relative forward-slash paths", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       expect(result).toBeInstanceOf(Map);
       expect([...result.keys()]).toEqual(
         expect.arrayContaining(["src/math.ts", "src/utils/format.ts"]),
@@ -21,7 +25,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("groups functions by file", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       expect(result.get("src/math.ts")).toHaveLength(3);
       expect(result.get("src/utils/format.ts")).toHaveLength(1);
     });
@@ -29,13 +33,13 @@ describe("V8CoverageAdapter", () => {
 
   describe("function extraction", () => {
     it("extracts function names from V8 functions array", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const names = result.get("src/math.ts")!.map((f) => f.name);
       expect(names).toEqual(["add", "divide", "neverCalled"]);
     });
 
     it("sets filePath to project-relative forward-slash path on each function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const fns = result.get("src/math.ts")!;
       for (const fn of fns) {
         expect(fn.filePath).toBe("src/math.ts");
@@ -43,7 +47,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("computes approximate spans from byte offsets (~40 chars/line)", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const add = result.get("src/math.ts")!.find((f) => f.name === "add")!;
       // startOffset=0 → startLine=1, endOffset=120 → endLine=ceil(120/40)+1=4
       expect(add.span.startLine).toBe(1);
@@ -55,7 +59,7 @@ describe("V8CoverageAdapter", () => {
 
   describe("line coverage (byte-based)", () => {
     it("computes 100% coverage for fully-covered function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const add = result.get("src/math.ts")!.find((f) => f.name === "add")!;
       // outer range {0,120,10}, sub-range {20,80,10} — no count=0 ranges
       expect(add.lineCoverage).toEqual({
@@ -66,7 +70,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("computes partial coverage when sub-ranges have count=0", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const divide = result
         .get("src/math.ts")!
         .find((f) => f.name === "divide")!;
@@ -78,7 +82,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("computes 0% coverage for completely uncovered function", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const neverCalled = result
         .get("src/math.ts")!
         .find((f) => f.name === "neverCalled")!;
@@ -91,7 +95,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("computes 100% for function with only covered ranges", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const formatName = result
         .get("src/utils/format.ts")!
         .find((f) => f.name === "formatName")!;
@@ -105,7 +109,7 @@ describe("V8CoverageAdapter", () => {
 
   describe("branch coverage", () => {
     it("returns null — raw V8 coverage lacks branch semantics", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const divide = result
         .get("src/math.ts")!
         .find((f) => f.name === "divide")!;
@@ -115,7 +119,7 @@ describe("V8CoverageAdapter", () => {
 
   describe("path normalization", () => {
     it("strips file:// prefix and cwd to produce forward-slash relative paths", () => {
-      const result = adapter.parse(loadFixture());
+      const result = adapter.parse(loadFixture()).coverage;
       const keys = [...result.keys()];
       for (const key of keys) {
         expect(key).not.toMatch(/^file:/);
@@ -126,7 +130,7 @@ describe("V8CoverageAdapter", () => {
 
     it("auto-detects common prefix when no cwd provided", () => {
       const autoAdapter = new V8CoverageAdapter();
-      const result = autoAdapter.parse(loadFixture());
+      const result = autoAdapter.parse(loadFixture()).coverage;
       // Common prefix of /projects/my-app/src/math.ts and /projects/my-app/src/utils/format.ts
       // is /projects/my-app/src/ → relative paths are math.ts and utils/format.ts
       expect([...result.keys()]).toEqual(
@@ -148,7 +152,7 @@ describe("V8CoverageAdapter", () => {
     });
 
     it("returns empty Map for empty result array", () => {
-      const result = adapter.parse({ result: [] });
+      const result = adapter.parse({ result: [] }).coverage;
       expect(result.size).toBe(0);
     });
 
@@ -173,7 +177,7 @@ describe("V8CoverageAdapter", () => {
           },
         ],
       };
-      const result = adapter.parse(data);
+      const result = adapter.parse(data).coverage;
       const fns = result.get("src/anon.ts")!;
       expect(fns).toHaveLength(1);
       expect(fns[0]!.name).toBe("named");
@@ -195,7 +199,7 @@ describe("V8CoverageAdapter", () => {
           },
         ],
       };
-      const result = adapter.parse(data);
+      const result = adapter.parse(data).coverage;
       const fns = result.get("src/empty.ts")!;
       expect(fns).toHaveLength(0);
     });
@@ -217,8 +221,195 @@ describe("V8CoverageAdapter", () => {
           },
         ],
       };
-      const result = winAdapter.parse(data);
+      const result = winAdapter.parse(data).coverage;
       expect([...result.keys()]).toContain("src/mod.ts");
     });
+  });
+
+  describe("three-tier line mapping", () => {
+    const sourceContent = "function add(a, b) {\n  return a + b;\n}\n\nfunction sub(a, b) {\n  return a - b;\n}\n";
+    // Line offsets: [0, 21, 37, 39, 40, 61, 77, 79]
+    // Line 1: bytes 0-20   "function add(a, b) {"
+    // Line 2: bytes 21-36  "  return a + b;"
+    // Line 3: bytes 37-38  "}"
+    // Line 4: bytes 39     ""
+    // Line 5: bytes 40-60  "function sub(a, b) {"
+    // Line 6: bytes 61-76  "  return a - b;"
+    // Line 7: bytes 77-78  "}"
+
+    it("uses line offset table (Tier 2) when source content is provided", () => {
+      const data = {
+        result: [
+          {
+            scriptId: "1",
+            url: "file:///projects/my-app/src/math.ts",
+            functions: [
+              {
+                functionName: "add",
+                ranges: [{ startOffset: 0, endOffset: 38, count: 1 }],
+                isBlockCoverage: true,
+              },
+              {
+                functionName: "sub",
+                ranges: [{ startOffset: 40, endOffset: 78, count: 1 }],
+                isBlockCoverage: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const sources = new Map([["src/math.ts", sourceContent]]);
+      const { coverage, warnings } = adapter.parse(data, sources);
+      const fns = coverage.get("src/math.ts")!;
+
+      // With source content, "add" starts at byte 0 → line 1, ends at byte 38 → line 3
+      expect(fns[0]!.span.startLine).toBe(1);
+      expect(fns[0]!.span.endLine).toBe(4); // exclusive
+
+      // "sub" starts at byte 40 → line 5, ends at byte 78 → line 7
+      expect(fns[1]!.span.startLine).toBe(5);
+      expect(fns[1]!.span.endLine).toBe(8); // exclusive
+
+      // No warnings since source was available
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("falls back to approximation (Tier 3) when no source content", () => {
+      const data = {
+        result: [
+          {
+            scriptId: "1",
+            url: "file:///projects/my-app/src/unknown.ts",
+            functions: [
+              {
+                functionName: "fn",
+                ranges: [{ startOffset: 0, endOffset: 120, count: 1 }],
+                isBlockCoverage: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const { coverage, warnings } = adapter.parse(data);
+      const fns = coverage.get("src/unknown.ts")!;
+
+      // Tier 3: startOffset=0 → line 1, endOffset=120 → ceil(120/40)+1=4
+      expect(fns[0]!.span.startLine).toBe(1);
+      expect(fns[0]!.span.endLine).toBe(4);
+
+      // Warning emitted for approximate span
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]!.code).toBe("approximate-span");
+      expect(warnings[0]!.file).toBe("src/unknown.ts");
+    });
+
+    it("emits one warning per file, not per function", () => {
+      const data = {
+        result: [
+          {
+            scriptId: "1",
+            url: "file:///projects/my-app/src/multi.ts",
+            functions: [
+              {
+                functionName: "fn1",
+                ranges: [{ startOffset: 0, endOffset: 80, count: 1 }],
+                isBlockCoverage: true,
+              },
+              {
+                functionName: "fn2",
+                ranges: [{ startOffset: 81, endOffset: 160, count: 1 }],
+                isBlockCoverage: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const { warnings } = adapter.parse(data);
+      expect(warnings).toHaveLength(1);
+    });
+
+    it("does not emit warning for files with source content", () => {
+      const data = {
+        result: [
+          {
+            scriptId: "1",
+            url: "file:///projects/my-app/src/known.ts",
+            functions: [
+              {
+                functionName: "fn",
+                ranges: [{ startOffset: 0, endOffset: 20, count: 1 }],
+                isBlockCoverage: true,
+              },
+            ],
+          },
+          {
+            scriptId: "2",
+            url: "file:///projects/my-app/src/unknown.ts",
+            functions: [
+              {
+                functionName: "fn2",
+                ranges: [{ startOffset: 0, endOffset: 20, count: 1 }],
+                isBlockCoverage: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      const sources = new Map([["src/known.ts", "const x = 1;\nconst y = 2;\n"]]);
+      const { warnings } = adapter.parse(data, sources);
+
+      // Only one warning for the file without source content
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]!.file).toBe("src/unknown.ts");
+    });
+  });
+});
+
+describe("buildLineOffsetTable", () => {
+  it("returns [0] for empty source", () => {
+    expect(buildLineOffsetTable("")).toEqual([0]);
+  });
+
+  it("returns correct offsets for multi-line source", () => {
+    const source = "abc\ndef\nghi\n";
+    // Line 1: bytes 0-3  "abc"
+    // Line 2: bytes 4-7  "def"
+    // Line 3: bytes 8-11 "ghi"
+    // Line 4: byte 12    ""
+    const table = buildLineOffsetTable(source);
+    expect(table).toEqual([0, 4, 8, 12]);
+  });
+
+  it("handles source without trailing newline", () => {
+    const source = "ab\ncd";
+    expect(buildLineOffsetTable(source)).toEqual([0, 3]);
+  });
+});
+
+describe("byteOffsetToLineFromTable", () => {
+  const table = [0, 4, 8, 12]; // Lines at bytes 0, 4, 8, 12
+
+  it("maps offset 0 to line 1", () => {
+    expect(byteOffsetToLineFromTable(0, table)).toBe(1);
+  });
+
+  it("maps offset within first line to line 1", () => {
+    expect(byteOffsetToLineFromTable(3, table)).toBe(1);
+  });
+
+  it("maps offset at line boundary to next line", () => {
+    expect(byteOffsetToLineFromTable(4, table)).toBe(2);
+  });
+
+  it("maps offset within second line to line 2", () => {
+    expect(byteOffsetToLineFromTable(6, table)).toBe(2);
+  });
+
+  it("maps offset past last line start to last line", () => {
+    expect(byteOffsetToLineFromTable(15, table)).toBe(4);
   });
 });

--- a/tests/adapters/reporters/console.test.ts
+++ b/tests/adapters/reporters/console.test.ts
@@ -3,7 +3,6 @@ import { ConsoleReporter } from "../../../src/adapters/reporters/console.js";
 import { RiskLevel } from "../../../src/domain/types.js";
 import type {
   AnalysisResult,
-  FileResult,
   FunctionVerdict,
   FunctionIdentity,
   CrapScore,
@@ -77,13 +76,15 @@ function makeSummary(overrides: Partial<AnalysisSummary> = {}): AnalysisSummary 
 }
 
 function makeResult(
-  files: FileResult[],
+  functions: FunctionVerdict[],
   summary: AnalysisSummary,
   passed: boolean,
   threshold = 12,
 ): AnalysisResult {
   return {
-    files,
+    functions,
+    unmatched: [],
+    warnings: [],
     summary,
     thresholdConfig: { defaultThreshold: threshold, overrides: [] } satisfies ThresholdConfig,
     passed,
@@ -99,31 +100,8 @@ describe("ConsoleReporter", () => {
       const v2 = makeVerdict("src/domain/services/pricing.ts", "applyDiscountRules", 8, 62.5, 30.4, 12);
       const v3 = makeVerdict("src/domain/lib/money.ts", "roundCurrency", 2, 100.0, 2.0, 12);
 
-      const file1: FileResult = {
-        filePath: "src/domain/services/pricing.ts",
-        functions: [v1, v2],
-        unmatched: [],
-        summary: {
-          totalFunctions: 2,
-          exceedingThreshold: 2,
-          maxCrap: makeScore(97.3),
-          averageCrap: 63.85,
-        },
-      };
-      const file2: FileResult = {
-        filePath: "src/domain/lib/money.ts",
-        functions: [v3],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(2.0),
-          averageCrap: 2.0,
-        },
-      };
-
       const result = makeResult(
-        [file1, file2],
+        [v1, v2, v3],
         makeSummary({
           totalFunctions: 47,
           totalFiles: 2,
@@ -176,20 +154,8 @@ describe("ConsoleReporter", () => {
       const v1 = makeVerdict("src/utils.ts", "add", 1, 100.0, 1.0, 12);
       const v2 = makeVerdict("src/utils.ts", "subtract", 1, 100.0, 1.0, 12);
 
-      const file: FileResult = {
-        filePath: "src/utils.ts",
-        functions: [v1, v2],
-        unmatched: [],
-        summary: {
-          totalFunctions: 2,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(1.0),
-          averageCrap: 1.0,
-        },
-      };
-
       const result = makeResult(
-        [file],
+        [v1, v2],
         makeSummary({
           totalFunctions: 2,
           totalFiles: 1,
@@ -210,20 +176,8 @@ describe("ConsoleReporter", () => {
     it("shows FAIL in summary when functions exceed threshold", () => {
       const v1 = makeVerdict("src/complex.ts", "doEverything", 20, 10.0, 380.0, 12);
 
-      const file: FileResult = {
-        filePath: "src/complex.ts",
-        functions: [v1],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(380.0),
-          averageCrap: 380.0,
-        },
-      };
-
       const result = makeResult(
-        [file],
+        [v1],
         makeSummary({
           totalFunctions: 1,
           totalFiles: 1,
@@ -277,26 +231,9 @@ describe("ConsoleReporter", () => {
     it("does not contain ANSI escape sequences when color is false", () => {
       const v1 = makeVerdict("src/foo.ts", "bar", 10, 30.0, 80.0, 12);
 
-      const file: FileResult = {
-        filePath: "src/foo.ts",
-        functions: [v1],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-          averageCrap: 80.0,
-        },
-      };
-
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 1,
-          totalFiles: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-        }),
+        [v1],
+        makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(80.0) }),
         false,
         12,
       );
@@ -304,34 +241,15 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: false });
       const output = reporter.format(result);
 
-      // ESC character = \x1b or \u001b — ANSI codes start with this
-       
       expect(output).not.toMatch(/\x1b\[/);
     });
 
     it("contains ANSI codes when color is true", () => {
       const v1 = makeVerdict("src/foo.ts", "bar", 10, 30.0, 80.0, 12);
 
-      const file: FileResult = {
-        filePath: "src/foo.ts",
-        functions: [v1],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-          averageCrap: 80.0,
-        },
-      };
-
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 1,
-          totalFiles: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-        }),
+        [v1],
+        makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(80.0) }),
         false,
         12,
       );
@@ -339,7 +257,6 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: true });
       const output = reporter.format(result);
 
-       
       expect(output).toMatch(/\x1b\[/);
     });
   });
@@ -347,14 +264,8 @@ describe("ConsoleReporter", () => {
   describe("color rules", () => {
     it("colorizes coverage red when below 50%", () => {
       const v = makeVerdict("src/a.ts", "fn", 5, 30.0, 20.0, 12);
-      const file: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 1, maxCrap: makeScore(20.0), averageCrap: 20.0 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(20.0) }),
         false,
       );
@@ -362,21 +273,13 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: true });
       const output = reporter.format(result);
 
-      // Red ANSI: \x1b[31m (or \x1b[91m for bright red)
-       
       expect(output).toMatch(/\x1b\[3?1m.*30\.0/s);
     });
 
     it("colorizes coverage yellow when 50-79%", () => {
       const v = makeVerdict("src/a.ts", "fn", 5, 65.0, 10.0, 12);
-      const file: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 0, maxCrap: makeScore(10.0), averageCrap: 10.0 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(10.0) }),
         true,
       );
@@ -384,21 +287,13 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: true });
       const output = reporter.format(result);
 
-      // Yellow ANSI: \x1b[33m
-       
       expect(output).toMatch(/\x1b\[33m.*65\.0/s);
     });
 
     it("colorizes coverage green when 80%+", () => {
       const v = makeVerdict("src/a.ts", "fn", 2, 95.0, 2.0, 12);
-      const file: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 0, maxCrap: makeScore(2.0), averageCrap: 2.0 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(2.0) }),
         true,
       );
@@ -406,21 +301,13 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: true });
       const output = reporter.format(result);
 
-      // Green ANSI: \x1b[32m
-       
       expect(output).toMatch(/\x1b\[32m.*95\.0/s);
     });
 
     it("colorizes above-threshold CRAP scores red+bold", () => {
       const v = makeVerdict("src/a.ts", "fn", 10, 30.0, 80.0, 12);
-      const file: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 1, maxCrap: makeScore(80.0), averageCrap: 80.0 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(80.0) }),
         false,
       );
@@ -446,25 +333,12 @@ describe("ConsoleReporter", () => {
   });
 
   describe("row ordering", () => {
-    it("outputs functions grouped by file, preserving file order", () => {
+    it("outputs functions preserving input order", () => {
       const v1 = makeVerdict("src/b.ts", "bFn", 1, 100.0, 1.0, 12);
       const v2 = makeVerdict("src/a.ts", "aFn", 1, 100.0, 1.0, 12);
 
-      const file1: FileResult = {
-        filePath: "src/b.ts",
-        functions: [v1],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 0, maxCrap: makeScore(1.0), averageCrap: 1.0 },
-      };
-      const file2: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v2],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 0, maxCrap: makeScore(1.0), averageCrap: 1.0 },
-      };
-
       const result = makeResult(
-        [file1, file2],
+        [v1, v2],
         makeSummary({ totalFunctions: 2, totalFiles: 2, maxCrap: makeScore(1.0) }),
         true,
       );
@@ -481,14 +355,8 @@ describe("ConsoleReporter", () => {
   describe("coverage formatting", () => {
     it("formats coverage with one decimal place", () => {
       const v = makeVerdict("src/x.ts", "fn", 1, 50.0, 1.0, 12);
-      const file: FileResult = {
-        filePath: "src/x.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 0, maxCrap: makeScore(1.0), averageCrap: 1.0 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(1.0) }),
         true,
       );
@@ -501,14 +369,8 @@ describe("ConsoleReporter", () => {
 
     it("formats CRAP with one decimal place", () => {
       const v = makeVerdict("src/x.ts", "fn", 5, 34.5, 12.03, 12);
-      const file: FileResult = {
-        filePath: "src/x.ts",
-        functions: [v],
-        unmatched: [],
-        summary: { totalFunctions: 1, exceedingThreshold: 1, maxCrap: makeScore(12.03), averageCrap: 12.03 },
-      };
       const result = makeResult(
-        [file],
+        [v],
         makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(12.03) }),
         false,
       );
@@ -516,7 +378,6 @@ describe("ConsoleReporter", () => {
       const reporter = new ConsoleReporter({ color: false });
       const output = reporter.format(result);
 
-      // Should show 12.0 (one decimal) — spec example shows one decimal
       expect(output).toMatch(/12\.0/);
     });
   });

--- a/tests/adapters/reporters/json.test.ts
+++ b/tests/adapters/reporters/json.test.ts
@@ -3,7 +3,6 @@ import { JsonReporter } from "../../../src/adapters/reporters/json.js";
 import { RiskLevel } from "../../../src/domain/types.js";
 import type {
   AnalysisResult,
-  FileResult,
   FunctionVerdict,
   FunctionIdentity,
   CrapScore,
@@ -77,13 +76,15 @@ function makeSummary(overrides: Partial<AnalysisSummary> = {}): AnalysisSummary 
 }
 
 function makeResult(
-  files: FileResult[],
+  functions: FunctionVerdict[],
   summary: AnalysisSummary,
   passed: boolean,
   threshold = 12,
 ): AnalysisResult {
   return {
-    files,
+    functions,
+    unmatched: [],
+    warnings: [],
     summary,
     thresholdConfig: { defaultThreshold: threshold, overrides: [] } satisfies ThresholdConfig,
     passed,
@@ -161,7 +162,9 @@ describe("JsonReporter", () => {
 
     it("includes config with overrides when present", () => {
       const analysisResult: AnalysisResult = {
-        files: [],
+        functions: [],
+        unmatched: [],
+        warnings: [],
         summary: makeSummary(),
         thresholdConfig: {
           defaultThreshold: 12,
@@ -197,46 +200,21 @@ describe("JsonReporter", () => {
       expect(parsed.summary).toEqual(summary);
     });
 
-    it("includes files array from AnalysisResult.files", () => {
+    it("includes functions array from AnalysisResult.functions", () => {
       const v1 = makeVerdict("src/pricing.ts", "calculateTotal", 12, 45.0, 97.3, 12);
       const v2 = makeVerdict("src/utils.ts", "add", 1, 100.0, 1.0, 12);
 
-      const file1: FileResult = {
-        filePath: "src/pricing.ts",
-        functions: [v1],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(97.3),
-          averageCrap: 97.3,
-        },
-      };
-      const file2: FileResult = {
-        filePath: "src/utils.ts",
-        functions: [v2],
-        unmatched: [],
-        summary: {
-          totalFunctions: 1,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(1.0),
-          averageCrap: 1.0,
-        },
-      };
-
       const result = makeResult(
-        [file1, file2],
+        [v1, v2],
         makeSummary({ totalFunctions: 2, totalFiles: 2, maxCrap: makeScore(97.3) }),
         false,
       );
       const output = reporter.format(result);
       const parsed = JSON.parse(output);
 
-      expect(parsed.files).toHaveLength(2);
-      expect(parsed.files[0].filePath).toBe("src/pricing.ts");
-      expect(parsed.files[1].filePath).toBe("src/utils.ts");
-      expect(parsed.files[0].functions).toHaveLength(1);
-      expect(parsed.files[0].functions[0].scored.identity.qualifiedName).toBe("calculateTotal");
+      expect(parsed.functions).toHaveLength(2);
+      expect(parsed.functions[0].scored.identity.qualifiedName).toBe("calculateTotal");
+      expect(parsed.functions[1].scored.identity.qualifiedName).toBe("add");
     });
 
     it("includes passed boolean from AnalysisResult.passed", () => {
@@ -252,45 +230,26 @@ describe("JsonReporter", () => {
 
     it("preserves all AnalysisResult data through serialization", () => {
       const v1 = makeVerdict("src/a.ts", "fnA", 5, 80.0, 6.25, 12);
-      const file: FileResult = {
-        filePath: "src/a.ts",
-        functions: [v1],
-        unmatched: [
-          {
-            kind: "no-coverage",
-            complexity: {
-              identity: makeIdentity("src/a.ts", "uncoveredFn"),
-              cyclomaticComplexity: 3,
-            },
-            worstCaseCrap: makeScore(12),
-          },
-        ],
-        summary: {
-          totalFunctions: 2,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(12),
-          averageCrap: 9.125,
-        },
-      };
 
       const summary = makeSummary({
-        totalFunctions: 2,
+        totalFunctions: 1,
         totalFiles: 1,
         exceedingThreshold: 0,
-        averageCrap: 9.125,
-        medianCrap: 9.125,
-        maxCrap: makeScore(12),
-        worstFunction: makeIdentity("src/a.ts", "uncoveredFn"),
-        distribution: makeDistribution(0, 1, 1, 0),
+        averageCrap: 6.25,
+        medianCrap: 6.25,
+        maxCrap: makeScore(6.25),
+        worstFunction: makeIdentity("src/a.ts", "fnA"),
+        distribution: makeDistribution(0, 1, 0, 0),
         crapLoad: 0,
       });
 
-      const result = makeResult([file], summary, true);
+      const result = makeResult([v1], summary, true);
       const output = reporter.format(result);
       const parsed = JSON.parse(output);
 
-      // Verify files, summary, passed are all preserved exactly
-      expect(parsed.files).toEqual(result.files);
+      // Verify functions, warnings, summary, passed are all preserved exactly
+      expect(parsed.functions).toEqual(result.functions);
+      expect(parsed.warnings).toEqual(result.warnings);
       expect(parsed.summary).toEqual(result.summary);
       expect(parsed.passed).toEqual(result.passed);
       expect(parsed.config).toEqual(result.thresholdConfig);
@@ -301,7 +260,8 @@ describe("JsonReporter", () => {
       const output = reporter.format(result);
       const parsed = JSON.parse(output);
 
-      expect(parsed.files).toEqual([]);
+      expect(parsed.functions).toEqual([]);
+      expect(parsed.warnings).toEqual([]);
       expect(parsed.summary.totalFunctions).toBe(0);
       expect(parsed.passed).toBe(true);
     });
@@ -317,7 +277,9 @@ describe("JsonReporter", () => {
       expect(keys).toContain("timestamp");
       expect(keys).toContain("config");
       expect(keys).toContain("summary");
-      expect(keys).toContain("files");
+      expect(keys).toContain("functions");
+      expect(keys).toContain("unmatched");
+      expect(keys).toContain("warnings");
       expect(keys).toContain("passed");
     });
 

--- a/tests/adapters/reporters/markdown.test.ts
+++ b/tests/adapters/reporters/markdown.test.ts
@@ -3,7 +3,6 @@ import { MarkdownReporter } from "../../../src/adapters/reporters/markdown.js";
 import { RiskLevel } from "../../../src/domain/types.js";
 import type {
   AnalysisResult,
-  FileResult,
   FunctionVerdict,
   FunctionIdentity,
   CrapScore,
@@ -89,50 +88,21 @@ function makeSummary(
 }
 
 function makeResult(
-  files: FileResult[],
+  functions: FunctionVerdict[],
   summary: AnalysisSummary,
   passed: boolean,
   threshold = 12,
 ): AnalysisResult {
   return {
-    files,
+    functions,
+    unmatched: [],
+    warnings: [],
     summary,
     thresholdConfig: {
       defaultThreshold: threshold,
       overrides: [],
     } satisfies ThresholdConfig,
     passed,
-  };
-}
-
-function makeFileResult(
-  filePath: string,
-  functions: FunctionVerdict[],
-  overrides: Partial<FileResult["summary"]> = {},
-): FileResult {
-  const maxCrap =
-    functions.length > 0
-      ? makeScore(
-          Math.max(...functions.map((f) => f.scored.crap.value)),
-        )
-      : makeScore(0);
-  const avgCrap =
-    functions.length > 0
-      ? functions.reduce((s, f) => s + f.scored.crap.value, 0) /
-        functions.length
-      : 0;
-
-  return {
-    filePath,
-    functions,
-    unmatched: [],
-    summary: {
-      totalFunctions: functions.length,
-      exceedingThreshold: functions.filter((f) => f.exceeds).length,
-      maxCrap,
-      averageCrap: avgCrap,
-      ...overrides,
-    },
   };
 }
 
@@ -151,34 +121,13 @@ describe("MarkdownReporter", () => {
 
   describe("result line", () => {
     it("shows FAIL with exceeding count, total, and threshold", () => {
-      const v1 = makeVerdict(
-        "src/domain/services/pricing.ts",
-        "calculateLineTotal",
-        12, 45.0, 97.3, 12, 42,
-      );
-      const v2 = makeVerdict(
-        "src/domain/services/pricing.ts",
-        "applyDiscountRules",
-        8, 62.5, 30.4, 12, 80,
-      );
-      const v3 = makeVerdict(
-        "src/domain/services/pricing.ts",
-        "formatInvoice",
-        6, 50.0, 15.2, 12, 120,
-      );
-
-      const file = makeFileResult("src/domain/services/pricing.ts", [
-        v1, v2, v3,
-      ]);
+      const v1 = makeVerdict("src/domain/services/pricing.ts", "calculateLineTotal", 12, 45.0, 97.3, 12, 42);
+      const v2 = makeVerdict("src/domain/services/pricing.ts", "applyDiscountRules", 8, 62.5, 30.4, 12, 80);
+      const v3 = makeVerdict("src/domain/services/pricing.ts", "formatInvoice", 6, 50.0, 15.2, 12, 120);
 
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 47,
-          totalFiles: 1,
-          exceedingThreshold: 3,
-          maxCrap: makeScore(97.3),
-        }),
+        [v1, v2, v3],
+        makeSummary({ totalFunctions: 47, totalFiles: 1, exceedingThreshold: 3, maxCrap: makeScore(97.3) }),
         false,
         12,
       );
@@ -186,23 +135,15 @@ describe("MarkdownReporter", () => {
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      expect(output).toContain(
-        "**Result: FAIL** | 3 of 47 functions above threshold (12)",
-      );
+      expect(output).toContain("**Result: FAIL** | 3 of 47 functions above threshold (12)");
     });
 
     it("shows PASS when no functions exceed threshold", () => {
       const v1 = makeVerdict("src/utils.ts", "add", 1, 100.0, 1.0, 12);
-      const file = makeFileResult("src/utils.ts", [v1]);
 
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 2,
-          totalFiles: 1,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(1.0),
-        }),
+        [v1],
+        makeSummary({ totalFunctions: 2, totalFiles: 1, exceedingThreshold: 0, maxCrap: makeScore(1.0) }),
         true,
         12,
       );
@@ -218,59 +159,40 @@ describe("MarkdownReporter", () => {
   describe("table structure", () => {
     it("has columns: CRAP, CC, Cov%, Function, Location", () => {
       const v1 = makeVerdict("src/a.ts", "fn", 5, 80.0, 6.25, 12, 10);
-      const file = makeFileResult("src/a.ts", [v1]);
 
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 1,
-          totalFiles: 1,
-          maxCrap: makeScore(6.25),
-        }),
+        [v1],
+        makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(6.25) }),
         true,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // Header row
       expect(output).toContain("| CRAP | CC | Cov% | Function | Location |");
-      // Alignment row — CRAP, CC, Cov% are right-aligned
       expect(output).toContain("|-----:|---:|-----:|----------|----------|");
     });
 
     it("formats data rows with CRAP, CC, Cov%, backtick function, backtick location", () => {
-      const v1 = makeVerdict(
-        "src/domain/services/pricing.ts",
-        "calculateLineTotal",
-        12, 45.0, 97.3, 12, 42,
-      );
-      const file = makeFileResult("src/domain/services/pricing.ts", [v1]);
+      const v1 = makeVerdict("src/domain/services/pricing.ts", "calculateLineTotal", 12, 45.0, 97.3, 12, 42);
 
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 1,
-          totalFiles: 1,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(97.3),
-        }),
+        [v1],
+        makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(97.3) }),
         false,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // Data row
       expect(output).toContain("| 97.3 | 12 | 45.0% | `calculateLineTotal` | `src/domain/services/pricing.ts:42` |");
     });
 
     it("formats coverage with one decimal place and % suffix", () => {
       const v1 = makeVerdict("src/a.ts", "fn", 1, 100.0, 1.0, 12);
-      const file = makeFileResult("src/a.ts", [v1]);
 
       const result = makeResult(
-        [file],
+        [v1],
         makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(1.0) }),
         true,
       );
@@ -283,10 +205,9 @@ describe("MarkdownReporter", () => {
 
     it("formats CRAP with one decimal place", () => {
       const v1 = makeVerdict("src/a.ts", "fn", 5, 34.5, 12.03, 12);
-      const file = makeFileResult("src/a.ts", [v1]);
 
       const result = makeResult(
-        [file],
+        [v1],
         makeSummary({ totalFunctions: 1, totalFiles: 1, exceedingThreshold: 1, maxCrap: makeScore(12.03) }),
         false,
       );
@@ -294,16 +215,14 @@ describe("MarkdownReporter", () => {
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // 12.03 formatted to one decimal = 12.0
       expect(output).toMatch(/\| 12\.0 \|/);
     });
 
     it("uses startLine from span in location format", () => {
       const v1 = makeVerdict("src/deep/nested/file.ts", "myFunc", 3, 70.0, 5.4, 12, 99);
-      const file = makeFileResult("src/deep/nested/file.ts", [v1]);
 
       const result = makeResult(
-        [file],
+        [v1],
         makeSummary({ totalFunctions: 1, totalFiles: 1, maxCrap: makeScore(5.4) }),
         true,
       );
@@ -321,20 +240,9 @@ describe("MarkdownReporter", () => {
       const v2 = makeVerdict("src/b.ts", "high", 12, 45.0, 97.3, 12, 5);
       const v3 = makeVerdict("src/c.ts", "mid", 5, 60.0, 15.0, 12, 10);
 
-      const files = [
-        makeFileResult("src/a.ts", [v1]),
-        makeFileResult("src/b.ts", [v2]),
-        makeFileResult("src/c.ts", [v3]),
-      ];
-
       const result = makeResult(
-        files,
-        makeSummary({
-          totalFunctions: 3,
-          totalFiles: 3,
-          exceedingThreshold: 2,
-          maxCrap: makeScore(97.3),
-        }),
+        [v1, v2, v3],
+        makeSummary({ totalFunctions: 3, totalFiles: 3, exceedingThreshold: 2, maxCrap: makeScore(97.3) }),
         false,
       );
 
@@ -356,36 +264,22 @@ describe("MarkdownReporter", () => {
       const passing1 = makeVerdict("src/b.ts", "goodFn", 1, 100.0, 1.0, 12, 5);
       const passing2 = makeVerdict("src/c.ts", "okFn", 2, 90.0, 2.1, 12, 10);
 
-      const files = [
-        makeFileResult("src/a.ts", [failing1]),
-        makeFileResult("src/b.ts", [passing1]),
-        makeFileResult("src/c.ts", [passing2]),
-      ];
-
       const result = makeResult(
-        files,
-        makeSummary({
-          totalFunctions: 3,
-          totalFiles: 3,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-        }),
+        [failing1, passing1, passing2],
+        makeSummary({ totalFunctions: 3, totalFiles: 3, exceedingThreshold: 1, maxCrap: makeScore(80.0) }),
         false,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // The failing function should appear above the fold (outside <details>)
       const detailsStart = output.indexOf("<details>");
       const badFnIdx = output.indexOf("`badFn`");
       expect(badFnIdx).toBeLessThan(detailsStart);
 
-      // The <details> block should contain all functions
       expect(output).toContain("<details><summary>Full results (3 functions)</summary>");
       expect(output).toContain("</details>");
 
-      // Inside the <details> block, all functions should appear
       const detailsContent = output.slice(
         output.indexOf("<details>"),
         output.indexOf("</details>") + "</details>".length,
@@ -399,16 +293,9 @@ describe("MarkdownReporter", () => {
       const v1 = makeVerdict("src/a.ts", "bad1", 10, 20.0, 80.0, 12, 1);
       const v2 = makeVerdict("src/a.ts", "bad2", 8, 30.0, 50.0, 12, 20);
 
-      const file = makeFileResult("src/a.ts", [v1, v2]);
-
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 2,
-          totalFiles: 1,
-          exceedingThreshold: 2,
-          maxCrap: makeScore(80.0),
-        }),
+        [v1, v2],
+        makeSummary({ totalFunctions: 2, totalFiles: 1, exceedingThreshold: 2, maxCrap: makeScore(80.0) }),
         false,
       );
 
@@ -423,47 +310,28 @@ describe("MarkdownReporter", () => {
       const v1 = makeVerdict("src/a.ts", "good1", 1, 100.0, 1.0, 12, 1);
       const v2 = makeVerdict("src/a.ts", "good2", 2, 90.0, 2.1, 12, 20);
 
-      const file = makeFileResult("src/a.ts", [v1, v2]);
-
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 2,
-          totalFiles: 1,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(2.1),
-        }),
+        [v1, v2],
+        makeSummary({ totalFunctions: 2, totalFiles: 1, exceedingThreshold: 0, maxCrap: makeScore(2.1) }),
         true,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // All functions shown in a single table, no <details> needed
       expect(output).not.toContain("<details>");
     });
 
     it("includes correct function count in <details> summary", () => {
       const verdicts: FunctionVerdict[] = [];
-      // 1 failing, 4 passing = 5 total
       verdicts.push(makeVerdict("src/a.ts", "fail1", 10, 10.0, 90.0, 12, 1));
       for (let i = 0; i < 4; i++) {
         verdicts.push(makeVerdict("src/b.ts", `pass${i}`, 1, 100.0, 1.0, 12, i * 10 + 1));
       }
 
-      const files = [
-        makeFileResult("src/a.ts", [verdicts[0]]),
-        makeFileResult("src/b.ts", verdicts.slice(1)),
-      ];
-
       const result = makeResult(
-        files,
-        makeSummary({
-          totalFunctions: 5,
-          totalFiles: 2,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(90.0),
-        }),
+        verdicts,
+        makeSummary({ totalFunctions: 5, totalFiles: 2, exceedingThreshold: 1, maxCrap: makeScore(90.0) }),
         false,
       );
 
@@ -476,18 +344,13 @@ describe("MarkdownReporter", () => {
 
   describe("empty results", () => {
     it("handles zero functions gracefully", () => {
-      const result = makeResult(
-        [],
-        makeSummary({ totalFunctions: 0, totalFiles: 0 }),
-        true,
-      );
+      const result = makeResult([], makeSummary({ totalFunctions: 0, totalFiles: 0 }), true);
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
       expect(output).toContain("## crap4ts Report");
       expect(output).toContain("**Result: PASS**");
-      // No table or details block
       expect(output).not.toContain("| CRAP |");
       expect(output).not.toContain("<details>");
     });
@@ -507,31 +370,17 @@ describe("MarkdownReporter", () => {
       const failing = makeVerdict("src/a.ts", "badFn", 10, 20.0, 80.0, 12, 1);
       const passing = makeVerdict("src/b.ts", "goodFn", 1, 100.0, 1.0, 12, 5);
 
-      const files = [
-        makeFileResult("src/a.ts", [failing]),
-        makeFileResult("src/b.ts", [passing]),
-      ];
-
       const result = makeResult(
-        files,
-        makeSummary({
-          totalFunctions: 2,
-          totalFiles: 2,
-          exceedingThreshold: 1,
-          maxCrap: makeScore(80.0),
-        }),
+        [failing, passing],
+        makeSummary({ totalFunctions: 2, totalFiles: 2, exceedingThreshold: 1, maxCrap: makeScore(80.0) }),
         false,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // Content before <details>
       const beforeDetails = output.slice(0, output.indexOf("<details>"));
-
-      // The failing function should be in the above-fold table
       expect(beforeDetails).toContain("`badFn`");
-      // The passing function should NOT be above the fold
       expect(beforeDetails).not.toContain("`goodFn`");
     });
 
@@ -539,16 +388,9 @@ describe("MarkdownReporter", () => {
       const v1 = makeVerdict("src/a.ts", "fn1", 1, 100.0, 1.0, 12, 1);
       const v2 = makeVerdict("src/a.ts", "fn2", 2, 90.0, 2.1, 12, 20);
 
-      const file = makeFileResult("src/a.ts", [v1, v2]);
-
       const result = makeResult(
-        [file],
-        makeSummary({
-          totalFunctions: 2,
-          totalFiles: 1,
-          exceedingThreshold: 0,
-          maxCrap: makeScore(2.1),
-        }),
+        [v1, v2],
+        makeSummary({ totalFunctions: 2, totalFiles: 1, exceedingThreshold: 0, maxCrap: makeScore(2.1) }),
         true,
       );
 
@@ -561,32 +403,20 @@ describe("MarkdownReporter", () => {
   });
 
   describe("multiple files", () => {
-    it("combines functions from all files and sorts globally", () => {
+    it("sorts functions globally by CRAP score descending", () => {
       const v1 = makeVerdict("src/a.ts", "aFn", 5, 60.0, 15.0, 12, 10);
       const v2 = makeVerdict("src/b.ts", "bFn", 12, 45.0, 97.3, 12, 42);
       const v3 = makeVerdict("src/c.ts", "cFn", 1, 100.0, 1.0, 12, 5);
 
-      const files = [
-        makeFileResult("src/a.ts", [v1]),
-        makeFileResult("src/b.ts", [v2]),
-        makeFileResult("src/c.ts", [v3]),
-      ];
-
       const result = makeResult(
-        files,
-        makeSummary({
-          totalFunctions: 3,
-          totalFiles: 3,
-          exceedingThreshold: 2,
-          maxCrap: makeScore(97.3),
-        }),
+        [v1, v2, v3],
+        makeSummary({ totalFunctions: 3, totalFiles: 3, exceedingThreshold: 2, maxCrap: makeScore(97.3) }),
         false,
       );
 
       const reporter = new MarkdownReporter();
       const output = reporter.format(result);
 
-      // bFn (97.3) should come before aFn (15.0)
       const bIdx = output.indexOf("`bFn`");
       const aIdx = output.indexOf("`aFn`");
       expect(bIdx).toBeLessThan(aIdx);

--- a/tests/core/analyze-file.test.ts
+++ b/tests/core/analyze-file.test.ts
@@ -68,7 +68,7 @@ function fakeCoveragePort(
 ): CoveragePort {
   return {
     parse() {
-      return coverageMap;
+      return { coverage: coverageMap, warnings: [] };
     },
   };
 }
@@ -119,7 +119,7 @@ describe("analyzeFile", () => {
       readJson: async () => ({ "src/math.ts": {} }),
     });
 
-    const verdicts = await analyzeFile(
+    const { verdicts } = await analyzeFile(
       "src/math.ts",
       { coverage: "/project/coverage.json" },
       deps,
@@ -148,7 +148,7 @@ describe("analyzeFile", () => {
       readFile: async () => "// source",
     });
 
-    const verdicts = await analyzeFile("src/utils.ts", undefined, deps);
+    const { verdicts } = await analyzeFile("src/utils.ts", undefined, deps);
 
     expect(verdicts).toHaveLength(2);
 
@@ -185,7 +185,7 @@ describe("analyzeFile", () => {
 
     // CRAP(4, 50%) = 16 * 0.125 + 4 = 6
     // With threshold 5 => exceeds
-    const verdicts = await analyzeFile(
+    const { verdicts } = await analyzeFile(
       "src/core.ts",
       { coverage: "/project/coverage.json", threshold: 5 },
       deps,
@@ -197,7 +197,7 @@ describe("analyzeFile", () => {
     expect(verdicts[0]!.exceeds).toBe(true);
 
     // With threshold 10 => does not exceed
-    const lenientVerdicts = await analyzeFile(
+    const { verdicts: lenientVerdicts } = await analyzeFile(
       "src/core.ts",
       { coverage: "/project/coverage.json", threshold: 10 },
       deps,
@@ -213,7 +213,7 @@ describe("analyzeFile", () => {
       readFile: async () => "const x = 42;",
     });
 
-    const verdicts = await analyzeFile("src/constants.ts", undefined, deps);
+    const { verdicts } = await analyzeFile("src/constants.ts", undefined, deps);
     expect(verdicts).toEqual([]);
   });
 
@@ -252,7 +252,7 @@ describe("analyzeFile", () => {
       readJson: async () => ({}),
     });
 
-    const verdicts = await analyzeFile(
+    const { verdicts } = await analyzeFile(
       "src/mix.ts",
       { coverage: "/project/coverage.json" },
       deps,

--- a/tests/core/analyze.test.ts
+++ b/tests/core/analyze.test.ts
@@ -68,7 +68,7 @@ function fakeCoveragePort(
 ): CoveragePort {
   return {
     parse() {
-      return coverageMap;
+      return { coverage: coverageMap, warnings: [] };
     },
   };
 }
@@ -109,7 +109,9 @@ describe("analyze", () => {
     const deps = createDeps();
     const result = await analyze({ cwd: "/project" }, deps);
 
-    expect(result.files).toEqual([]);
+    expect(result.functions).toEqual([]);
+    expect(result.unmatched).toEqual([]);
+    expect(result.warnings).toEqual([]);
     expect(result.summary.totalFunctions).toBe(0);
     expect(result.passed).toBe(true);
   });
@@ -133,11 +135,10 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files[0]!.filePath).toBe("src/math.ts");
-    expect(result.files[0]!.functions).toHaveLength(1);
+    expect(result.functions).toHaveLength(1);
 
-    const verdict = result.files[0]!.functions[0]!;
+    const verdict = result.functions[0]!;
+    expect(verdict.scored.identity.filePath).toBe("src/math.ts");
     expect(verdict.scored.cyclomaticComplexity).toBe(3);
     expect(verdict.scored.coveragePercent).toBe(80);
     // CRAP(3, 80%) = 3^2 * 0.2^3 + 3 = 9 * 0.008 + 3 = 3.07
@@ -167,8 +168,8 @@ describe("analyze", () => {
     const result = await analyze({ cwd: "/project" }, deps);
 
     // CRAP(10, 0%) = 10^2 * 1^3 + 10 = 110
-    expect(result.files[0]!.functions[0]!.threshold).toBe(12);
-    expect(result.files[0]!.functions[0]!.exceeds).toBe(true);
+    expect(result.functions[0]!.threshold).toBe(12);
+    expect(result.functions[0]!.exceeds).toBe(true);
     expect(result.passed).toBe(false);
   });
 
@@ -193,8 +194,8 @@ describe("analyze", () => {
     const result = await analyze({ cwd: "/project", threshold: 5 }, deps);
 
     expect(result.thresholdConfig.defaultThreshold).toBe(5);
-    expect(result.files[0]!.functions[0]!.threshold).toBe(5);
-    expect(result.files[0]!.functions[0]!.exceeds).toBe(true);
+    expect(result.functions[0]!.threshold).toBe(5);
+    expect(result.functions[0]!.exceeds).toBe(true);
   });
 
   it("passed=true when no functions exceed threshold", async () => {
@@ -286,8 +287,8 @@ describe("analyze", () => {
 
     expect(result.thresholdConfig.overrides).toHaveLength(1);
     expect(result.thresholdConfig.overrides[0]!.glob).toBe("src/legacy/**");
-    expect(result.files[0]!.functions[0]!.threshold).toBe(50);
-    expect(result.files[0]!.functions[0]!.exceeds).toBe(false);
+    expect(result.functions[0]!.threshold).toBe(50);
+    expect(result.functions[0]!.exceeds).toBe(false);
     expect(result.passed).toBe(true);
   });
 
@@ -307,13 +308,14 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files[0]!.unmatched).toHaveLength(1);
-    expect(result.files[0]!.unmatched[0]!.kind).toBe("no-coverage");
-    if (result.files[0]!.unmatched[0]!.kind === "no-coverage") {
+    expect(result.unmatched).toHaveLength(1);
+    expect(result.unmatched[0]!.kind).toBe("no-coverage");
+    if (result.unmatched[0]!.kind === "no-coverage") {
       // CRAP(5, 0%) = 25 * 1 + 5 = 30
-      expect(result.files[0]!.unmatched[0]!.worstCaseCrap.value).toBe(30);
+      expect(result.unmatched[0]!.worstCaseCrap.value).toBe(30);
     }
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.code).toBe("unmatched-no-coverage");
   });
 
   it("unmatched coverage entries get no-ast kind", async () => {
@@ -332,17 +334,16 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    // The file should still appear due to unmatched coverage
-    const fileResult = result.files.find((f) => f.filePath === "src/orphan.ts");
-    expect(fileResult).toBeDefined();
-    expect(fileResult!.unmatched).toHaveLength(1);
-    expect(fileResult!.unmatched[0]!.kind).toBe("no-ast");
-    if (fileResult!.unmatched[0]!.kind === "no-ast") {
-      expect(fileResult!.unmatched[0]!.coverage.name).toBe("mystery");
+    expect(result.unmatched).toHaveLength(1);
+    expect(result.unmatched[0]!.kind).toBe("no-ast");
+    if (result.unmatched[0]!.kind === "no-ast") {
+      expect(result.unmatched[0]!.coverage.name).toBe("mystery");
     }
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.code).toBe("unmatched-no-ast");
   });
 
-  it("groups function results by file path", async () => {
+  it("returns flat functions from multiple files", async () => {
     const compA1 = makeComplexity("src/a.ts", "fn1", 2, span(1, 5));
     const compA2 = makeComplexity("src/a.ts", "fn2", 3, span(6, 12));
     const compB1 = makeComplexity("src/b.ts", "fn3", 1, span(1, 8));
@@ -376,18 +377,16 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    expect(result.files).toHaveLength(2);
+    expect(result.functions).toHaveLength(3);
 
-    const fileA = result.files.find((f) => f.filePath === "src/a.ts");
-    const fileB = result.files.find((f) => f.filePath === "src/b.ts");
+    const fileAPaths = result.functions.filter((f) => f.scored.identity.filePath === "src/a.ts");
+    const fileBPaths = result.functions.filter((f) => f.scored.identity.filePath === "src/b.ts");
 
-    expect(fileA).toBeDefined();
-    expect(fileA!.functions).toHaveLength(2);
-    expect(fileB).toBeDefined();
-    expect(fileB!.functions).toHaveLength(1);
+    expect(fileAPaths).toHaveLength(2);
+    expect(fileBPaths).toHaveLength(1);
   });
 
-  it("computes per-file summary stats", async () => {
+  it("computes overall summary stats", async () => {
     const comp1 = makeComplexity("src/file.ts", "low", 1, span(1, 5));
     const comp2 = makeComplexity("src/file.ts", "high", 15, span(6, 20));
     const cov1 = makeCoverage("src/file.ts", "low", 100, span(1, 5));
@@ -411,11 +410,10 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    const file = result.files[0]!;
-    expect(file.summary.totalFunctions).toBe(2);
+    expect(result.summary.totalFunctions).toBe(2);
     // CRAP(15, 0%) = 225 + 15 = 240 => exceeds 12
-    expect(file.summary.exceedingThreshold).toBe(1);
-    expect(file.summary.maxCrap.value).toBe(240);
+    expect(result.summary.exceedingThreshold).toBe(1);
+    expect(result.summary.maxCrap.value).toBe(240);
   });
 
   it("uses line coverage by default, branch when specified", async () => {
@@ -439,14 +437,14 @@ describe("analyze", () => {
 
     // Default (line): CRAP(2, 90%) = 4 * 0.001 + 2 = 2.004 => 2
     const lineResult = await analyze({ cwd: "/project" }, deps);
-    expect(lineResult.files[0]!.functions[0]!.scored.coveragePercent).toBe(90);
+    expect(lineResult.functions[0]!.scored.coveragePercent).toBe(90);
 
     // Branch: CRAP(2, 50%) = 4 * 0.125 + 2 = 2.5
     const branchResult = await analyze(
       { cwd: "/project", coverageMetric: "branch" },
       deps,
     );
-    expect(branchResult.files[0]!.functions[0]!.scored.coveragePercent).toBe(50);
+    expect(branchResult.functions[0]!.scored.coveragePercent).toBe(50);
   });
 
   it("falls back to line coverage when branch is requested but null", async () => {
@@ -473,7 +471,7 @@ describe("analyze", () => {
       deps,
     );
     // Falls back to line coverage since branchCoverage is null
-    expect(result.files[0]!.functions[0]!.scored.coveragePercent).toBe(80);
+    expect(result.functions[0]!.scored.coveragePercent).toBe(80);
   });
 
   it("changedSince option filters to only changed files", async () => {
@@ -515,8 +513,8 @@ describe("analyze", () => {
       },
     );
 
-    expect(result.files).toHaveLength(1);
-    expect(result.files[0]!.filePath).toBe("src/changed.ts");
+    expect(result.functions).toHaveLength(1);
+    expect(result.functions[0]!.scored.identity.filePath).toBe("src/changed.ts");
   });
 
   it("returns thresholdConfig in result", async () => {
@@ -575,8 +573,9 @@ describe("analyze", () => {
 
     const result = await analyze({ cwd: "/project" }, deps);
 
-    // 2 matched functions + 1 file with unmatched
-    expect(result.files.length).toBeGreaterThanOrEqual(2);
+    // 2 matched functions + 1 unmatched
+    expect(result.functions).toHaveLength(2);
+    expect(result.unmatched).toHaveLength(1);
     expect(result.summary.totalFunctions).toBe(2); // only matched get verdicts
     expect(result.passed).toBe(false); // CRAP(20, 10%) is huge
   });
@@ -586,7 +585,7 @@ describe("analyze", () => {
     const result = await analyze(undefined, deps);
 
     // Should not throw and produce an empty result
-    expect(result.files).toEqual([]);
+    expect(result.functions).toEqual([]);
     expect(result.passed).toBe(true);
   });
 
@@ -657,5 +656,37 @@ describe("analyze", () => {
       expect(excludePatterns).toContain("**/node_modules/**");
       expect(excludePatterns).toContain("**/*.test.ts");
     });
+  });
+
+  it("forwards source content to coveragePort.parse for accurate line mapping", async () => {
+    const comp = makeComplexity("src/math.ts", "add", 2, span(1, 5));
+    const cov = makeCoverage("src/math.ts", "add", 100, span(1, 5));
+    const sourceContent = "function add(a, b) { return a + b; }";
+
+    let receivedSources: ReadonlyMap<string, string> | undefined;
+
+    const deps = createDeps({
+      complexityPort: fakeComplexityPort(
+        new Map([["src/math.ts", [comp]]]),
+      ),
+      coveragePort: {
+        parse(_data: unknown, sources?: ReadonlyMap<string, string>) {
+          receivedSources = sources;
+          return {
+            coverage: new Map([["src/math.ts", [cov]]]),
+            warnings: [],
+          };
+        },
+      },
+      matcher: fakeMatcher([{ complexity: comp, coverage: cov }]),
+      findFiles: async () => ["src/math.ts"],
+      readFile: async () => sourceContent,
+      readJson: async () => ({}),
+    });
+
+    await analyze({ cwd: "/project", coverage: "/project/coverage.json" }, deps);
+
+    expect(receivedSources).toBeDefined();
+    expect(receivedSources!.get("src/math.ts")).toBe(sourceContent);
   });
 });


### PR DESCRIPTION
## Summary

- **Issue #3**: Replace file-grouped `AnalysisResult.files` with flat `functions`, `unmatched`, and `warnings` arrays. Add `Warning`/`WarningCode` domain types. JSON envelope now includes `functions`, `unmatched`, `warnings` at top level.
- **Issue #5**: Three-tier byte-to-line conversion in V8 adapter — accurate line offset table (Tier 2) when source content is available, approximation with `approximate-span` warning (Tier 3) when not. `CoveragePort.parse()` returns `CoverageParseResult` with warnings.
- **Review fixes**: `analyzeFile` propagates warnings and passes source content, CLI renders warnings with `--verbose`, `CoverageParseResult` uses `ReadonlyMap`.

### Breaking changes
- `AnalysisResult.files` → `AnalysisResult.functions` (flat array)
- `FileResult` type removed
- `CoveragePort.parse()` returns `CoverageParseResult` instead of bare `Map`
- `analyzeFile()` returns `AnalyzeFileResult` instead of `FunctionVerdict[]`

### Verification
- 330 tests passing (14 new)
- Typecheck, lint, build all clean
- Dogfood: correct envelope shape confirmed

Closes #3, closes #5

## Test plan
- [x] All 330 tests pass (`npm run test`)
- [x] Typecheck clean (`npm run typecheck`)
- [x] Lint clean (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Dogfood: JSON output has correct envelope keys
- [x] V8 three-tier line mapping tests (source content, no source, warning dedup)
- [x] `analyzeFile` returns warnings and forwards source content
- [x] `sources` map forwarding test in `analyze.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)