### PR TITLE
fix(core): default to 100% coverage for branchless functions with branch metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ export default defineConfig({
 });
 ```
 
+### Coverage Metric
+
+The `coverageMetric` option controls which coverage data is used for CRAP scoring:
+
+- **`"line"`** (default) — Uses line coverage percentages.
+- **`"branch"`** — Uses branch coverage percentages. When a function has no branches (e.g., a simple function with no `if`/`switch`/`??`), branch coverage defaults to **100%** since there are no branches to test.
+
 ## Coverage Format Support
 
 | Format | Source | Status |

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -242,8 +242,10 @@ export function extractCoveragePercent(
   coverage: FunctionCoverage,
   metric: "line" | "branch",
 ): number {
-  if (metric === "branch" && coverage.branchCoverage !== null) {
-    return coverage.branchCoverage.percent;
+  if (metric === "branch") {
+    return coverage.branchCoverage !== null
+      ? coverage.branchCoverage.percent
+      : 100; // No branches = fully covered
   }
   return coverage.lineCoverage.percent;
 }

--- a/tests/core/analyze-file.test.ts
+++ b/tests/core/analyze-file.test.ts
@@ -234,6 +234,39 @@ describe("analyzeFile", () => {
     ).rejects.toThrow("File not found");
   });
 
+  it("defaults to 100% coverage when branch metric requested but function has no branches", async () => {
+    const comp = makeComplexity("src/simple.ts", "add", 1, span(1, 5));
+    const cov: FunctionCoverage = {
+      filePath: "src/simple.ts",
+      name: "add",
+      span: span(1, 5),
+      lineCoverage: ratio(4, 10), // 40%
+      branchCoverage: null, // no branches
+    };
+
+    const deps = createDeps({
+      complexityPort: fakeComplexityPort([comp]),
+      coveragePort: fakeCoveragePort(
+        new Map([["src/simple.ts", [cov]]]),
+      ),
+      matcher: fakeMatcher([{ complexity: comp, coverage: cov }]),
+      readFile: async () => "// source",
+      readJson: async () => ({}),
+    });
+
+    const { verdicts } = await analyzeFile(
+      "src/simple.ts",
+      { coverage: "/project/coverage.json", coverageMetric: "branch" },
+      deps,
+    );
+
+    expect(verdicts).toHaveLength(1);
+    // No branches = 100% branch coverage, not 40% line coverage fallback
+    expect(verdicts[0]!.scored.coveragePercent).toBe(100);
+    // CRAP(1, 100%) = 1^2 * 0^3 + 1 = 1
+    expect(verdicts[0]!.scored.crap.value).toBe(1);
+  });
+
   it("handles multiple functions with mixed match/unmatch results", async () => {
     const compMatched = makeComplexity("src/mix.ts", "covered", 2, span(1, 8));
     const compUnmatched = makeComplexity("src/mix.ts", "uncovered", 6, span(9, 20));

--- a/tests/core/analyze.test.ts
+++ b/tests/core/analyze.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { analyze } from "../../src/core/analyze.js";
+import { analyze, extractCoveragePercent } from "../../src/core/analyze.js";
 import type {
   FunctionComplexity,
   FunctionCoverage,
@@ -447,7 +447,7 @@ describe("analyze", () => {
     expect(branchResult.functions[0]!.scored.coveragePercent).toBe(50);
   });
 
-  it("falls back to line coverage when branch is requested but null", async () => {
+  it("defaults to 100% when branch metric requested but function has no branches", async () => {
     const comp = makeComplexity("src/x.ts", "fn", 2, span(1, 10));
     const cov: FunctionCoverage = {
       filePath: "src/x.ts",
@@ -470,8 +470,8 @@ describe("analyze", () => {
       { cwd: "/project", coverageMetric: "branch" },
       deps,
     );
-    // Falls back to line coverage since branchCoverage is null
-    expect(result.functions[0]!.scored.coveragePercent).toBe(80);
+    // No branches means fully covered — should be 100%, not line coverage fallback
+    expect(result.functions[0]!.scored.coveragePercent).toBe(100);
   });
 
   it("changedSince option filters to only changed files", async () => {
@@ -688,5 +688,41 @@ describe("analyze", () => {
 
     expect(receivedSources).toBeDefined();
     expect(receivedSources!.get("src/math.ts")).toBe(sourceContent);
+  });
+});
+
+describe("extractCoveragePercent", () => {
+  it("returns line coverage percent when metric is 'line'", () => {
+    const cov: FunctionCoverage = {
+      filePath: "src/x.ts",
+      name: "fn",
+      span: span(1, 10),
+      lineCoverage: ratio(7, 10), // 70%
+      branchCoverage: ratio(3, 10), // 30%
+    };
+    expect(extractCoveragePercent(cov, "line")).toBe(70);
+  });
+
+  it("returns branch coverage percent when metric is 'branch' and branches exist", () => {
+    const cov: FunctionCoverage = {
+      filePath: "src/x.ts",
+      name: "fn",
+      span: span(1, 10),
+      lineCoverage: ratio(7, 10), // 70%
+      branchCoverage: ratio(3, 10), // 30%
+    };
+    expect(extractCoveragePercent(cov, "branch")).toBe(30);
+  });
+
+  it("returns 100 when metric is 'branch' but branchCoverage is null (no branches)", () => {
+    const cov: FunctionCoverage = {
+      filePath: "src/x.ts",
+      name: "fn",
+      span: span(1, 10),
+      lineCoverage: ratio(5, 10), // 50%
+      branchCoverage: null,
+    };
+    // No branches = nothing to test = 100% covered
+    expect(extractCoveragePercent(cov, "branch")).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary
- When `coverageMetric === "branch"` and `branchCoverage === null`, return 100% instead of falling back to line coverage
- No branches = nothing to test = fully covered
- Added unit tests for `extractCoveragePercent` and integration test in analyze-file
- Documented behavior in README

## Quality
- All 334 tests passing
- Typecheck, lint, build clean

## Test plan
- [x] Failing tests written first (TDD)
- [x] Fix verified against regression suite
- [x] `npm run typecheck && npm run lint && npm run test && npm run build` all pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)