### PR TITLE
feat: implement line-level diff filtering for --changed-since (#2)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,74 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    // ── Hexagonal: domain/ imports NOTHING from other layers ──
+    {
+      name: "domain-no-outward-deps",
+      comment: "Domain must not import from ports, adapters, core, or cli",
+      severity: "error",
+      from: { path: "^src/domain/" },
+      to: {
+        path: "^src/(ports|adapters|core|cli)/",
+      },
+    },
+    // ── Hexagonal: domain/ must not use Node APIs ──
+    {
+      name: "domain-no-node-apis",
+      comment: "Domain must be pure — no Node built-in imports",
+      severity: "error",
+      from: { path: "^src/domain/" },
+      to: {
+        path: "^node:",
+      },
+    },
+    // ── Hexagonal: ports/ only import from domain ──
+    {
+      name: "ports-only-import-domain",
+      comment: "Ports may only import from domain (types)",
+      severity: "error",
+      from: { path: "^src/ports/" },
+      to: {
+        path: "^src/(adapters|core|cli)/",
+      },
+    },
+    // ── Hexagonal: adapters/ must not import from core or cli ──
+    {
+      name: "adapters-no-core-or-cli",
+      comment: "Adapters implement ports, must not import core or cli",
+      severity: "error",
+      from: { path: "^src/adapters/" },
+      to: {
+        path: "^src/(core|cli)/",
+      },
+    },
+    // ── Hexagonal: core/ must not import from cli ──
+    {
+      name: "core-no-cli",
+      comment: "Core must not import from cli",
+      severity: "error",
+      from: { path: "^src/core/" },
+      to: {
+        path: "^src/cli/",
+      },
+    },
+    // ── No circular dependencies ──
+    {
+      name: "no-circular",
+      comment: "No circular dependencies allowed",
+      severity: "error",
+      from: {},
+      to: {
+        circular: true,
+      },
+    },
+  ],
+  options: {
+    doNotFollow: {
+      path: "node_modules",
+    },
+    tsPreCompilationDeps: true,
+    tsConfig: {
+      fileName: "tsconfig.json",
+    },
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ reports/
 *.tsbuildinfo
 .DS_Store
 
+# Logs
+*.log
+
 # Claude Code
 .claude/*
 !.claude/rules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap4ts",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap4ts",
-      "version": "0.0.1",
+      "version": "0.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0",
@@ -27,6 +27,7 @@
         "@types/node": "^22.0.0",
         "@types/picomatch": "^3.0.0",
         "@vitest/coverage-v8": "^3.0.0",
+        "dependency-cruiser": "^17.3.9",
         "eslint": "^9.0.0",
         "prettier": "^3.0.0",
         "tsup": "^8.0.0",
@@ -2765,6 +2766,39 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3191,6 +3225,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dependency-cruiser": {
+      "version": "17.3.9",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.3.9.tgz",
+      "integrity": "sha512-LwaotlB9bZ8zhdFGGYf/g2oYkYj7YNxlqx1btL/XIYGob/aKRArsSwkLKo+ZrHiegsEArQVg4ZQ3NhAh8uk+hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.16.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.20.0",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.3",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.7.4",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^20.12||^22||>=24"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -3244,6 +3336,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3977,6 +4083,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -4002,6 +4124,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4117,6 +4246,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4148,6 +4313,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -4376,6 +4571,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4532,6 +4737,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -4821,6 +5036,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -5020,6 +5242,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5060,6 +5296,29 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5068,6 +5327,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -5133,6 +5413,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safer-buffer": {
@@ -5273,6 +5563,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -5411,6 +5708,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -5501,6 +5808,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/test-exclude": {
@@ -5629,6 +5963,70 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -6031,6 +6429,19 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^20.12||^22.13||>=24.0"
       }
     },
     "node_modules/weapon-regex": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/node": "^22.0.0",
     "@types/picomatch": "^3.0.0",
     "@vitest/coverage-v8": "^3.0.0",
+    "dependency-cruiser": "^17.3.9",
     "eslint": "^9.0.0",
     "prettier": "^3.0.0",
     "tsup": "^8.0.0",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -15,8 +15,7 @@ import {
   discoverSourceRoot,
   formatCoverageNotFoundError,
 } from "./discover.js";
-// getChangedFiles is available for future --changed-since enhancements
-// import { getChangedFiles } from "./diff.js";
+import { getChangedFiles } from "./diff.js";
 import { ConsoleReporter } from "../adapters/reporters/console.js";
 import { JsonReporter } from "../adapters/reporters/json.js";
 import { MarkdownReporter } from "../adapters/reporters/markdown.js";
@@ -217,7 +216,9 @@ program.action(async (opts: Record<string, unknown>) => {
         coverageMetric: resolved.coverageMetric ?? "line",
         include: resolved.include,
         exclude: resolved.exclude,
-        changedSince: changedSinceRef,
+        filter: changedSinceRef
+          ? await getChangedFiles(changedSinceRef, { cwd })
+          : undefined,
         cwd,
       });
     } catch (err) {
@@ -357,7 +358,7 @@ function sortVerdicts(
   verdicts: FunctionVerdict[],
   field: string,
 ): FunctionVerdict[] {
-  const sorted = [...verdicts];
+  const sorted = verdicts;
 
   switch (field) {
     case "crap":

--- a/src/cli/diff.ts
+++ b/src/cli/diff.ts
@@ -19,13 +19,90 @@ const defaultExec: ExecFn = async (command: string, args: string[]) => {
     const { stdout } = await execFileAsync(command, args);
     return { stdout, exitCode: 0 };
   } catch (error: unknown) {
-    const execError = error as { stdout?: string; code?: number };
-    return {
-      stdout: execError.stdout ?? "",
-      exitCode: execError.code ?? 1,
-    };
+    if (error instanceof Error && "code" in error) {
+      const execError = error as { stdout?: string; code?: number | string };
+      // ENOENT = binary not found in PATH
+      if (execError.code === "ENOENT") {
+        throw new Error(`"${command}" is not installed or not in PATH`);
+      }
+      // Normal child process non-zero exit
+      if (typeof execError.code === "number") {
+        return {
+          stdout: execError.stdout ?? "",
+          exitCode: execError.code,
+        };
+      }
+    }
+    // Unexpected error shape — do not suppress
+    throw error;
   }
 };
+
+// ── parseUnifiedDiff ────────────────────────────────────────────────
+
+/** Captures file path from "diff --git a/... b/..." */
+const DIFF_HEADER_RE = /^diff --git a\/.+ b\/(.+)$/;
+/** Captures start line and optional count from "@@ -old +start,count @@" */
+const HUNK_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+/**
+ * Parses `git diff --unified=0` output into a map of file paths to
+ * line-level spans. New files (--- /dev/null) map to `null` (whole-file).
+ */
+export function parseUnifiedDiff(
+  raw: string,
+): Map<string, ReadonlyArray<SourceSpan> | null> {
+  const result = new Map<string, ReadonlyArray<SourceSpan> | null>();
+  if (!raw.trim()) return result;
+
+  let currentFile: string | null = null;
+  let isNewFile = false;
+  let spans: SourceSpan[] = [];
+
+  const flushFile = () => {
+    if (currentFile !== null) {
+      if (isNewFile) {
+        result.set(currentFile, null);
+      } else {
+        result.set(currentFile, spans);
+      }
+    }
+  };
+
+  for (const line of raw.split("\n")) {
+    const headerMatch = line.match(DIFF_HEADER_RE);
+    if (headerMatch) {
+      flushFile();
+      currentFile = headerMatch[1]!.replace(/\\/g, "/");
+      isNewFile = false;
+      spans = [];
+      continue;
+    }
+
+    if (line === "--- /dev/null") {
+      isNewFile = true;
+      continue;
+    }
+
+    const hunkMatch = line.match(HUNK_RE);
+    if (hunkMatch && !isNewFile) {
+      const start = parseInt(hunkMatch[1]!, 10);
+      const count = hunkMatch[2] !== undefined ? parseInt(hunkMatch[2]!, 10) : 1;
+      // count=0 means deletion-only hunk (no new lines added); skip
+      if (count > 0) {
+        spans.push({
+          startLine: start,
+          endLine: start + count,
+          startColumn: 0,
+          endColumn: 0,
+        });
+      }
+    }
+  }
+
+  flushFile();
+  return result;
+}
 
 // ── getChangedFiles ─────────────────────────────────────────────────
 
@@ -35,11 +112,9 @@ interface GetChangedFilesOptions {
 }
 
 /**
- * Runs `git diff --name-only <ref>` and produces a FunctionFilter
- * where each changed file maps to `null` spans (whole-file changed).
- *
- * V1 uses whole-file filtering only — line-level span filtering
- * is a future enhancement.
+ * Runs `git diff --unified=0 <ref>` and produces a FunctionFilter
+ * with line-level spans for each changed file.
+ * New files map to `null` (whole-file changed).
  */
 export async function getChangedFiles(
   ref: string,
@@ -55,27 +130,17 @@ export async function getChangedFiles(
   const exec = options?.exec ?? defaultExec;
 
   // Use -- separator to prevent git from interpreting ref as flags
-  const { stdout, exitCode } = await exec("git", ["diff", "--name-only", ref, "--"]);
+  const { stdout, exitCode } = await exec("git", ["diff", "--unified=0", ref, "--"]);
+  const safeRef = ref.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
 
   if (exitCode !== 0) {
-    const safeRef = ref.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
     throw new Error(
       `git diff failed with exit code ${exitCode}: ${stdout.trim()} (ref: ${safeRef})`,
     );
   }
 
-  const files = stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .map((file) => file.replace(/\\/g, "/"));
+  const changedFiles = parseUnifiedDiff(stdout);
 
-  const changedFiles = new Map<string, ReadonlyArray<SourceSpan> | null>();
-  for (const file of files) {
-    changedFiles.set(file, null);
-  }
-
-  const safeRef = ref.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
   return {
     description: `Changed since ${safeRef}`,
     changedFiles,

--- a/src/core/analyze-file.ts
+++ b/src/core/analyze-file.ts
@@ -12,7 +12,7 @@ import type {
   ThresholdConfig,
 } from "../domain/types.js";
 import { extractCoveragePercent, flattenCoverages } from "./analyze.js";
-import type { AnalyzeDeps } from "./analyze.js";
+import type { AnalyzeDeps } from "./deps.js";
 
 // ── Single-File Analysis ──────────────────────────────────────────
 

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -5,6 +5,7 @@ import {
   resolveThreshold,
 } from "../domain/threshold.js";
 import { computeSummary } from "../domain/summary.js";
+import { shouldInclude } from "../domain/filtering.js";
 import type {
   AnalyzeOptions,
   AnalysisResult,
@@ -13,28 +14,12 @@ import type {
   Warning,
   FunctionComplexity,
   FunctionCoverage,
-  MatchFunctions,
+  FunctionFilter,
   ThresholdConfig,
   ScoredFunction,
 } from "../domain/types.js";
-import type { ComplexityPort } from "../ports/complexity-port.js";
-import type { CoveragePort } from "../ports/coverage-port.js";
-import type { GlobMatcher } from "../domain/threshold.js";
-
-// ── Dependency Injection Interface ────────────────────────────────
-
-export interface AnalyzeDeps {
-  complexityPort: ComplexityPort;
-  coveragePort: CoveragePort;
-  matcher: MatchFunctions;
-  globMatcher: GlobMatcher;
-  readFile: (path: string) => Promise<string>;
-  readJson: (path: string) => Promise<unknown>;
-  findFiles: (
-    patterns: string[],
-    options: { cwd: string; exclude: string[] },
-  ) => Promise<string[]>;
-}
+import type { AnalyzeDeps } from "./deps.js";
+export type { AnalyzeDeps };
 
 // ── Main Entry Point ──────────────────────────────────────────────
 
@@ -72,17 +57,22 @@ export async function analyze(
     allComplexities.push(...fileComplexities);
   }
 
-  // 4. Read coverage data (pass source content for accurate line mapping)
+  // 4. Apply function filter (if provided)
+  const complexitiesToMatch = opts.filter
+    ? allComplexities.filter((c) => shouldInclude(opts.filter!, c.identity))
+    : allComplexities;
+
+  // 5. Read coverage data (pass source content for accurate line mapping)
   const { coverage: coverageData, warnings: coverageWarnings } =
     await loadCoverageData(resolvedDeps, opts.coveragePath, sourceContents);
 
-  // 5. Flatten all coverage data
+  // 6. Flatten all coverage data
   const allCoverages = flattenCoverages(coverageData);
 
-  // 6. Match complexity with coverage
-  const matchResult = resolvedDeps.matcher(allComplexities, allCoverages);
+  // 7. Match complexity with coverage
+  const matchResult = resolvedDeps.matcher(complexitiesToMatch, allCoverages);
 
-  // 7. Score each matched pair and create verdicts
+  // 8. Score each matched pair and create verdicts
   const allVerdicts: FunctionVerdict[] = [];
   const allUnmatched: UnmatchedFunction[] = [];
 
@@ -109,7 +99,7 @@ export async function analyze(
     });
   }
 
-  // 8. Handle unmatched complexity (no-coverage: worst-case 0%)
+  // 9. Handle unmatched complexity (no-coverage: worst-case 0%)
   for (const complexity of matchResult.unmatchedComplexity) {
     const worstCaseCrap = computeCrap(complexity.cyclomaticComplexity, 0);
     allUnmatched.push({
@@ -119,7 +109,7 @@ export async function analyze(
     });
   }
 
-  // 9. Handle unmatched coverage (no-ast: informational)
+  // 10. Handle unmatched coverage (no-ast: informational)
   for (const coverage of matchResult.unmatchedCoverage) {
     allUnmatched.push({
       kind: "no-ast",
@@ -127,8 +117,15 @@ export async function analyze(
     });
   }
 
-  // 10. Collect warnings from coverage parsing and unmatched
+  // 11. Collect warnings from coverage parsing, unmatched, and filter
   const warnings: Warning[] = [...coverageWarnings];
+
+  if (opts.filter && complexitiesToMatch.length === 0 && allComplexities.length > 0) {
+    warnings.push({
+      code: "filter-excluded-all",
+      message: `Filter "${opts.filter.description}" excluded all ${allComplexities.length} functions. No functions overlap with changed lines.`,
+    });
+  }
   for (const u of allUnmatched) {
     if (u.kind === "no-coverage") {
       warnings.push({
@@ -147,10 +144,10 @@ export async function analyze(
     }
   }
 
-  // 11. Compute overall summary
+  // 12. Compute overall summary
   const summary = computeSummary(allVerdicts);
 
-  // 12. Determine pass/fail
+  // 13. Determine pass/fail
   const passed = allVerdicts.every((v) => !v.exceeds);
 
   return { functions: allVerdicts, unmatched: allUnmatched, warnings, summary, thresholdConfig, passed };
@@ -174,6 +171,7 @@ interface ResolvedOptions {
   coverageMetric: "line" | "branch";
   include: string[];
   exclude: string[];
+  filter: FunctionFilter | undefined;
 }
 
 function resolveIncludePatterns(options?: AnalyzeOptions): string[] {
@@ -201,6 +199,7 @@ function resolveOptions(options?: AnalyzeOptions): ResolvedOptions {
     coverageMetric: opts.coverageMetric ?? "line",
     include: resolveIncludePatterns(options),
     exclude: opts.exclude ?? DEFAULT_EXCLUDE,
+    filter: opts.filter,
   };
 }
 
@@ -245,7 +244,7 @@ export function extractCoveragePercent(
   if (metric === "branch") {
     return coverage.branchCoverage !== null
       ? coverage.branchCoverage.percent
-      : 100; // No branches = fully covered
+      : 100; // A function with no branches has trivially 100% branch coverage
   }
   return coverage.lineCoverage.percent;
 }

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -6,7 +6,7 @@ import { defaultSpanMatcher } from "../domain/matching.js";
 import picomatch from "picomatch";
 import { readFile, readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
-import type { AnalyzeDeps } from "./analyze.js";
+import type { AnalyzeDeps } from "./deps.js";
 import type { CoveragePort, CoverageParseResult } from "../ports/coverage-port.js";
 
 // ── Auto-Detecting Coverage Port ──────────────────────────────────

--- a/src/core/deps.ts
+++ b/src/core/deps.ts
@@ -1,0 +1,19 @@
+import type { MatchFunctions } from "../domain/types.js";
+import type { ComplexityPort } from "../ports/complexity-port.js";
+import type { CoveragePort } from "../ports/coverage-port.js";
+import type { GlobMatcher } from "../domain/threshold.js";
+
+// ── Dependency Injection Interface ────────────────────────────────
+
+export interface AnalyzeDeps {
+  complexityPort: ComplexityPort;
+  coveragePort: CoveragePort;
+  matcher: MatchFunctions;
+  globMatcher: GlobMatcher;
+  readFile: (path: string) => Promise<string>;
+  readJson: (path: string) => Promise<unknown>;
+  findFiles: (
+    patterns: string[],
+    options: { cwd: string; exclude: string[] },
+  ) => Promise<string[]>;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,5 @@
 export { analyze } from "./analyze.js";
-export type { AnalyzeDeps } from "./analyze.js";
+export type { AnalyzeDeps } from "./deps.js";
 export { analyzeFile } from "./analyze-file.js";
 export type { AnalyzeFileOptions, AnalyzeFileResult } from "./analyze-file.js";
 export { defineConfig } from "./define-config.js";
@@ -15,6 +15,7 @@ export type {
   ScoredFunction,
   CrapScore,
   FunctionIdentity,
+  FunctionFilter,
   SourceSpan,
   ThresholdConfig,
   ThresholdOverride,

--- a/src/domain/filtering.ts
+++ b/src/domain/filtering.ts
@@ -1,0 +1,25 @@
+import type { SourceSpan, FunctionFilter, FunctionIdentity } from "./types.js";
+
+/**
+ * Returns true if two half-open spans [startLine, endLine) share any lines.
+ */
+export function spansOverlap(a: SourceSpan, b: SourceSpan): boolean {
+  return a.startLine < b.endLine && b.startLine < a.endLine;
+}
+
+/**
+ * Returns true if a function should be included based on the filter.
+ *
+ * - File not in filter map → exclude
+ * - File mapped to null → include (whole-file changed)
+ * - File mapped to spans → include if any span overlaps function's span
+ */
+export function shouldInclude(
+  filter: FunctionFilter,
+  identity: FunctionIdentity,
+): boolean {
+  const entry = filter.changedFiles.get(identity.filePath);
+  if (entry === undefined) return false;
+  if (entry === null) return true;
+  return entry.some((changedSpan) => spansOverlap(identity.span, changedSpan));
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -88,7 +88,8 @@ export type WarningCode =
   | "unmatched-no-coverage"
   | "unmatched-no-ast"
   | "approximate-span"
-  | "missing-coverage-file";
+  | "missing-coverage-file"
+  | "filter-excluded-all";
 
 export interface Warning {
   readonly code: WarningCode;
@@ -175,7 +176,7 @@ export interface AnalyzeOptions {
   coverageMetric?: "line" | "branch";
   include?: string[];
   exclude?: string[];
-  changedSince?: string;
+  filter?: FunctionFilter;
   cwd?: string;
   signal?: AbortSignal;
 }

--- a/tests/cli/diff-parsing.feature
+++ b/tests/cli/diff-parsing.feature
@@ -1,0 +1,34 @@
+Feature: Git diff hunk parsing
+
+  The CLI parses unified diff output to build a filter
+  with line-level spans for each changed file.
+
+  Scenario: Single hunk produces one span
+    Given a diff with one hunk adding lines 10 to 15 in "app.ts"
+    When the diff is parsed into a filter
+    Then the filter maps "app.ts" to a span from line 10 to 15
+
+  Scenario: Multiple hunks in one file produce multiple spans
+    Given a diff with hunks adding lines 5 to 10 and 30 to 35 in "app.ts"
+    When the diff is parsed into a filter
+    Then the filter maps "app.ts" to two spans
+
+  Scenario: Deletion-only hunk produces no span
+    Given a diff with a hunk that only deletes lines in "old.ts"
+    When the diff is parsed into a filter
+    Then the filter maps "old.ts" to an empty span list
+
+  Scenario: New file maps to whole-file
+    Given a diff showing "new-file.ts" as entirely new
+    When the diff is parsed into a filter
+    Then the filter maps "new-file.ts" to whole-file
+
+  Scenario: Multiple files each get their own spans
+    Given a diff with changes in "a.ts" and "b.ts"
+    When the diff is parsed into a filter
+    Then the filter contains entries for both files
+
+  Scenario: Single-line addition produces a one-line span
+    Given a diff adding one line at line 42 in "fix.ts"
+    When the diff is parsed into a filter
+    Then the filter maps "fix.ts" to a span from line 42 to 43

--- a/tests/cli/diff.test.ts
+++ b/tests/cli/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getChangedFiles, type ExecFn } from "../../src/cli/diff.js";
+import { getChangedFiles, parseUnifiedDiff, type ExecFn } from "../../src/cli/diff.js";
 
 // ── Exec Helpers ────────────────────────────────────────────────────
 
@@ -10,39 +10,188 @@ function createMockExec(
   return async (_command: string, _args: string[]) => ({ stdout, exitCode });
 }
 
+// ── parseUnifiedDiff ────────────────────────────────────────────────
+
+describe("parseUnifiedDiff", () => {
+  it("single hunk adding lines 10 to 15 produces one span", () => {
+    const diff = [
+      "diff --git a/app.ts b/app.ts",
+      "index abc123..def456 100644",
+      "--- a/app.ts",
+      "+++ b/app.ts",
+      "@@ -5,3 +10,5 @@ function foo() {",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.get("app.ts")).toEqual([
+      { startLine: 10, endLine: 15, startColumn: 0, endColumn: 0 },
+    ]);
+  });
+
+  it("multiple hunks in one file produce multiple spans", () => {
+    const diff = [
+      "diff --git a/app.ts b/app.ts",
+      "index abc123..def456 100644",
+      "--- a/app.ts",
+      "+++ b/app.ts",
+      "@@ -1,3 +5,5 @@ function foo() {",
+      "@@ -20,2 +30,5 @@ function bar() {",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    const spans = result.get("app.ts");
+    expect(spans).toEqual([
+      { startLine: 5, endLine: 10, startColumn: 0, endColumn: 0 },
+      { startLine: 30, endLine: 35, startColumn: 0, endColumn: 0 },
+    ]);
+  });
+
+  it("deletion-only hunk (count=0) produces empty span list", () => {
+    const diff = [
+      "diff --git a/old.ts b/old.ts",
+      "index abc123..def456 100644",
+      "--- a/old.ts",
+      "+++ b/old.ts",
+      "@@ -5,3 +5,0 @@ function removed() {",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.get("old.ts")).toEqual([]);
+  });
+
+  it("new file (--- /dev/null) maps to null (whole-file)", () => {
+    const diff = [
+      "diff --git a/dev/null b/new-file.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/new-file.ts",
+      "@@ -0,0 +1,42 @@",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.get("new-file.ts")).toBeNull();
+  });
+
+  it("multiple files each get their own spans", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "index abc123..def456 100644",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,5 @@ function x() {",
+      "diff --git a/b.ts b/b.ts",
+      "index 111222..333444 100644",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -10,3 +10,4 @@ function y() {",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.has("a.ts")).toBe(true);
+    expect(result.has("b.ts")).toBe(true);
+    expect(result.get("a.ts")).toEqual([
+      { startLine: 1, endLine: 6, startColumn: 0, endColumn: 0 },
+    ]);
+    expect(result.get("b.ts")).toEqual([
+      { startLine: 10, endLine: 14, startColumn: 0, endColumn: 0 },
+    ]);
+  });
+
+  it("single-line addition at line 42 produces span [42, 43)", () => {
+    const diff = [
+      "diff --git a/fix.ts b/fix.ts",
+      "index abc123..def456 100644",
+      "--- a/fix.ts",
+      "+++ b/fix.ts",
+      "@@ -40,0 +42 @@ function fix() {",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.get("fix.ts")).toEqual([
+      { startLine: 42, endLine: 43, startColumn: 0, endColumn: 0 },
+    ]);
+  });
+
+  it("normalizes backslash paths to forward slashes", () => {
+    const diff = [
+      "diff --git a/src\\cli\\diff.ts b/src\\cli\\diff.ts",
+      "index abc123..def456 100644",
+      "--- a/src\\cli\\diff.ts",
+      "+++ b/src\\cli\\diff.ts",
+      "@@ -1,2 +1,3 @@",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.has("src/cli/diff.ts")).toBe(true);
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = parseUnifiedDiff("");
+    expect(result.size).toBe(0);
+  });
+
+  it("handles explicit +start,1 as count=1", () => {
+    const diff = [
+      "diff --git a/x.ts b/x.ts",
+      "index abc..def 100644",
+      "--- a/x.ts",
+      "+++ b/x.ts",
+      "@@ -10,1 +20,1 @@",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(diff);
+    expect(result.get("x.ts")).toEqual([
+      { startLine: 20, endLine: 21, startColumn: 0, endColumn: 0 },
+    ]);
+  });
+});
+
 // ── getChangedFiles ─────────────────────────────────────────────────
 
 describe("getChangedFiles", () => {
-  it("returns a FunctionFilter with changed files as keys", async () => {
-    const exec = createMockExec("src/foo.ts\nsrc/bar.ts\n");
-    const filter = await getChangedFiles("main", { exec });
+  it("passes --unified=0 to git diff", async () => {
+    let capturedArgs: string[] = [];
+    const exec: ExecFn = async (_command: string, args: string[]) => {
+      capturedArgs = args;
+      return { stdout: "", exitCode: 0 };
+    };
 
-    expect(filter.changedFiles.size).toBe(2);
-    expect(filter.changedFiles.has("src/foo.ts")).toBe(true);
-    expect(filter.changedFiles.has("src/bar.ts")).toBe(true);
+    await getChangedFiles("HEAD~3", { exec });
+
+    expect(capturedArgs).toEqual(["diff", "--unified=0", "HEAD~3", "--"]);
   });
 
-  it("sets null spans for each file (whole-file changed)", async () => {
-    const exec = createMockExec("src/foo.ts\n");
+  it("parses unified diff output into line-level spans", async () => {
+    const diffOutput = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "index abc..def 100644",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -1,3 +1,5 @@ function foo() {",
+      "",
+    ].join("\n");
+    const exec = createMockExec(diffOutput);
     const filter = await getChangedFiles("main", { exec });
 
-    expect(filter.changedFiles.get("src/foo.ts")).toBeNull();
+    expect(filter.changedFiles.size).toBe(1);
+    expect(filter.changedFiles.get("src/foo.ts")).toEqual([
+      { startLine: 1, endLine: 6, startColumn: 0, endColumn: 0 },
+    ]);
   });
 
-  it("normalizes paths to forward slashes", async () => {
-    const exec = createMockExec("src\\cli\\diff.ts\n");
+  it("maps new files to null (whole-file)", async () => {
+    const diffOutput = [
+      "diff --git a/dev/null b/src/new.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/src/new.ts",
+      "@@ -0,0 +1,10 @@",
+      "",
+    ].join("\n");
+    const exec = createMockExec(diffOutput);
     const filter = await getChangedFiles("main", { exec });
 
-    expect(filter.changedFiles.has("src/cli/diff.ts")).toBe(true);
-  });
-
-  it("trims whitespace and filters empty lines", async () => {
-    const exec = createMockExec("  src/a.ts  \n\n  src/b.ts\n\n");
-    const filter = await getChangedFiles("main", { exec });
-
-    expect(filter.changedFiles.size).toBe(2);
-    expect(filter.changedFiles.has("src/a.ts")).toBe(true);
-    expect(filter.changedFiles.has("src/b.ts")).toBe(true);
+    expect(filter.changedFiles.get("src/new.ts")).toBeNull();
   });
 
   it("returns empty changedFiles map for empty diff", async () => {
@@ -52,22 +201,15 @@ describe("getChangedFiles", () => {
     expect(filter.changedFiles.size).toBe(0);
   });
 
-  it("returns empty changedFiles map for whitespace-only diff", async () => {
-    const exec = createMockExec("  \n  \n");
-    const filter = await getChangedFiles("main", { exec });
-
-    expect(filter.changedFiles.size).toBe(0);
-  });
-
   it("includes ref in description", async () => {
-    const exec = createMockExec("src/foo.ts\n");
+    const exec = createMockExec("");
     const filter = await getChangedFiles("abc123", { exec });
 
     expect(filter.description).toBe("Changed since abc123");
   });
 
   it("includes branch name in description", async () => {
-    const exec = createMockExec("src/foo.ts\n");
+    const exec = createMockExec("");
     const filter = await getChangedFiles("origin/main", { exec });
 
     expect(filter.description).toBe("Changed since origin/main");
@@ -89,36 +231,6 @@ describe("getChangedFiles", () => {
     );
   });
 
-  it("passes correct git arguments to exec", async () => {
-    let capturedCommand = "";
-    let capturedArgs: string[] = [];
-    const exec: ExecFn = async (command: string, args: string[]) => {
-      capturedCommand = command;
-      capturedArgs = args;
-      return { stdout: "", exitCode: 0 };
-    };
-
-    await getChangedFiles("HEAD~3", { exec });
-
-    expect(capturedCommand).toBe("git");
-    expect(capturedArgs).toEqual(["diff", "--name-only", "HEAD~3", "--"]);
-  });
-
-  it("handles single file without trailing newline", async () => {
-    const exec = createMockExec("src/only.ts");
-    const filter = await getChangedFiles("main", { exec });
-
-    expect(filter.changedFiles.size).toBe(1);
-    expect(filter.changedFiles.has("src/only.ts")).toBe(true);
-  });
-
-  it("deduplicates repeated file paths", async () => {
-    const exec = createMockExec("src/foo.ts\nsrc/foo.ts\n");
-    const filter = await getChangedFiles("main", { exec });
-
-    expect(filter.changedFiles.size).toBe(1);
-  });
-
   // ── Security: argument injection prevention ──────────────────────
 
   it("rejects refs that start with a dash (flag injection)", async () => {
@@ -138,7 +250,7 @@ describe("getChangedFiles", () => {
   });
 
   it("strips control characters from ref in description", async () => {
-    const exec = createMockExec("src/foo.ts\n");
+    const exec = createMockExec("");
     const filter = await getChangedFiles("main\x1b[31m", { exec });
 
     expect(filter.description).not.toContain("\x1b");

--- a/tests/core/analyze.test.ts
+++ b/tests/core/analyze.test.ts
@@ -3,6 +3,7 @@ import { analyze, extractCoveragePercent } from "../../src/core/analyze.js";
 import type {
   FunctionComplexity,
   FunctionCoverage,
+  FunctionFilter,
   MatchResult,
   MatchFunctions,
   SourceSpan,
@@ -474,47 +475,143 @@ describe("analyze", () => {
     expect(result.functions[0]!.scored.coveragePercent).toBe(100);
   });
 
-  it("changedSince option filters to only changed files", async () => {
-    // findFiles returns all source files, but we only analyze changed ones
-    const comp = makeComplexity("src/changed.ts", "fn", 2, span(1, 10));
-    const cov = makeCoverage("src/changed.ts", "fn", 100, span(1, 10));
+  describe("filter integration", () => {
+    // Three functions in one file with distinct spans
+    const comp1 = makeComplexity("src/app.ts", "fn1", 2, span(1, 10));
+    const comp2 = makeComplexity("src/app.ts", "fn2", 3, span(15, 25));
+    const comp3 = makeComplexity("src/app.ts", "fn3", 1, span(30, 40));
+    const cov1 = makeCoverage("src/app.ts", "fn1", 80, span(1, 10));
+    const cov2 = makeCoverage("src/app.ts", "fn2", 60, span(15, 25));
+    const cov3 = makeCoverage("src/app.ts", "fn3", 100, span(30, 40));
 
-    const filesRequested: string[] = [];
+    function depsForFilter(
+      complexities: FunctionComplexity[],
+      coverages: FunctionCoverage[],
+    ): AnalyzeDeps {
+      // Use a real-ish matcher that pairs by name
+      const matcher: MatchFunctions = (comps, covs) => {
+        const matched: Array<{ complexity: FunctionComplexity; coverage: FunctionCoverage }> = [];
+        const unmatchedComplexity: FunctionComplexity[] = [];
+        for (const c of comps) {
+          const cov = covs.find((cv) => cv.name === c.identity.qualifiedName);
+          if (cov) {
+            matched.push({ complexity: c, coverage: cov });
+          } else {
+            unmatchedComplexity.push(c);
+          }
+        }
+        return { matched, unmatchedComplexity, unmatchedCoverage: [] };
+      };
 
-    const deps = createDeps({
-      complexityPort: {
-        extract(_, filePath) {
-          filesRequested.push(filePath);
-          if (filePath === "src/changed.ts") return [comp];
-          return [];
-        },
-      },
-      coveragePort: fakeCoveragePort(
-        new Map([["src/changed.ts", [cov]]]),
-      ),
-      matcher: fakeMatcher([{ complexity: comp, coverage: cov }]),
-      // findFiles returns all files initially, but changedSince filters them
-      findFiles: async () => ["src/changed.ts", "src/unchanged.ts"],
-      readFile: async () => "// source",
-      readJson: async () => ({}),
+      return createDeps({
+        complexityPort: fakeComplexityPort(
+          new Map([["src/app.ts", complexities]]),
+        ),
+        coveragePort: fakeCoveragePort(
+          new Map([["src/app.ts", coverages]]),
+        ),
+        matcher,
+        findFiles: async () => ["src/app.ts"],
+        readFile: async () => "// source",
+        readJson: async () => ({}),
+      });
+    }
+
+    it("only changed functions are scored", async () => {
+      const filter: FunctionFilter = {
+        description: "test filter",
+        changedFiles: new Map([["src/app.ts", [span(18, 22)]]]),
+      };
+      const deps = depsForFilter([comp1, comp2, comp3], [cov1, cov2, cov3]);
+
+      const result = await analyze({ cwd: "/project", coverage: "/project/coverage.json", filter }, deps);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0]!.scored.identity.qualifiedName).toBe("fn2");
     });
 
-    const result = await analyze(
-      {
-        cwd: "/project",
-        changedSince: "main",
-        // We simulate the git diff filter by providing a custom findFiles
-        // In reality, changedSince would invoke git, but here we test the filtering
-      },
-      {
-        ...deps,
-        // Override findFiles to simulate changedSince filtering
-        findFiles: async () => ["src/changed.ts"],
-      },
-    );
+    it("no filter scores all functions", async () => {
+      const deps = depsForFilter([comp1, comp2, comp3], [cov1, cov2, cov3]);
 
-    expect(result.functions).toHaveLength(1);
-    expect(result.functions[0]!.scored.identity.filePath).toBe("src/changed.ts");
+      const result = await analyze({ cwd: "/project", coverage: "/project/coverage.json" }, deps);
+
+      expect(result.functions).toHaveLength(3);
+    });
+
+    it("whole-file filter (null spans) scores all functions in that file", async () => {
+      const filter: FunctionFilter = {
+        description: "whole file changed",
+        changedFiles: new Map([["src/app.ts", null]]),
+      };
+      const deps = depsForFilter([comp1, comp2, comp3], [cov1, cov2, cov3]);
+
+      const result = await analyze({ cwd: "/project", coverage: "/project/coverage.json", filter }, deps);
+
+      expect(result.functions).toHaveLength(3);
+    });
+
+    it("emits filter-excluded-all warning when filter matches no functions", async () => {
+      const filter: FunctionFilter = {
+        description: "changes in other file",
+        changedFiles: new Map([["src/other.ts", [span(1, 5)]]]),
+      };
+      const deps = depsForFilter([comp1, comp2, comp3], [cov1, cov2, cov3]);
+
+      const result = await analyze({ cwd: "/project", coverage: "/project/coverage.json", filter }, deps);
+
+      expect(result.functions).toHaveLength(0);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "filter-excluded-all",
+        }),
+      );
+    });
+
+    it("functions in unchanged files are excluded", async () => {
+      const compB = makeComplexity("src/b.ts", "other", 4, span(1, 10));
+      const covB = makeCoverage("src/b.ts", "other", 50, span(1, 10));
+
+      const filter: FunctionFilter = {
+        description: "only a.ts changed",
+        changedFiles: new Map([["src/a.ts", null]]),
+      };
+
+      const compA = makeComplexity("src/a.ts", "kept", 2, span(1, 10));
+      const covA = makeCoverage("src/a.ts", "kept", 90, span(1, 10));
+
+      const matcher: MatchFunctions = (comps, covs) => {
+        const matched: Array<{ complexity: FunctionComplexity; coverage: FunctionCoverage }> = [];
+        for (const c of comps) {
+          const cov = covs.find((cv) => cv.name === c.identity.qualifiedName);
+          if (cov) matched.push({ complexity: c, coverage: cov });
+        }
+        return { matched, unmatchedComplexity: [], unmatchedCoverage: [] };
+      };
+
+      const deps = createDeps({
+        complexityPort: fakeComplexityPort(
+          new Map([
+            ["src/a.ts", [compA]],
+            ["src/b.ts", [compB]],
+          ]),
+        ),
+        coveragePort: fakeCoveragePort(
+          new Map([
+            ["src/a.ts", [covA]],
+            ["src/b.ts", [covB]],
+          ]),
+        ),
+        matcher,
+        findFiles: async () => ["src/a.ts", "src/b.ts"],
+        readFile: async () => "// source",
+        readJson: async () => ({}),
+      });
+
+      const result = await analyze({ cwd: "/project", coverage: "/project/coverage.json", filter }, deps);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0]!.scored.identity.filePath).toBe("src/a.ts");
+    });
   });
 
   it("returns thresholdConfig in result", async () => {

--- a/tests/core/filtering-integration.feature
+++ b/tests/core/filtering-integration.feature
@@ -1,0 +1,29 @@
+Feature: Analysis pipeline with diff filtering
+
+  When a filter is provided, only functions whose spans
+  overlap changed lines are scored. The rest of the
+  pipeline remains unchanged.
+
+  Scenario: Only changed functions are scored
+    Given a source file with three functions
+    And a filter indicating changes inside the second function only
+    When analysis is run with the filter
+    Then only the second function appears in the results
+
+  Scenario: No filter scores all functions
+    Given a source file with three functions
+    And no filter is provided
+    When analysis is run
+    Then all three functions appear in the results
+
+  Scenario: Whole-file filter scores all functions in that file
+    Given a source file with three functions
+    And a filter marking the file as whole-file changed
+    When analysis is run with the filter
+    Then all three functions appear in the results
+
+  Scenario: Functions in unchanged files are excluded
+    Given two source files with functions in each
+    And a filter that only includes the first file
+    When analysis is run with the filter
+    Then only functions from the first file appear in the results

--- a/tests/domain/filtering.feature
+++ b/tests/domain/filtering.feature
@@ -1,0 +1,62 @@
+Feature: Function-level diff filtering
+
+  Functions should only be scored when their source lines overlap
+  with lines that were added or modified in a diff.
+
+  # --- Span overlap ---
+
+  Scenario: Function spans overlap when they share lines
+    Given a function spanning lines 5 to 15
+    And a changed region spanning lines 10 to 20
+    When checking for overlap
+    Then the spans overlap
+
+  Scenario: Function spans do not overlap when separated
+    Given a function spanning lines 5 to 10
+    And a changed region spanning lines 15 to 20
+    When checking for overlap
+    Then the spans do not overlap
+
+  Scenario: Adjacent spans do not overlap under half-open convention
+    Given a function spanning lines 5 to 10
+    And a changed region spanning lines 10 to 15
+    When checking for overlap
+    Then the spans do not overlap
+
+  Scenario: Single-line change inside a function
+    Given a function spanning lines 1 to 50
+    And a changed region spanning lines 25 to 26
+    When checking for overlap
+    Then the spans overlap
+
+  # --- shouldInclude decisions ---
+
+  Scenario: File not in the filter excludes all its functions
+    Given a filter with no entry for "utils.ts"
+    And a function in "utils.ts"
+    When deciding whether to include the function
+    Then the function is excluded
+
+  Scenario: File mapped to null includes all its functions
+    Given a filter where "utils.ts" maps to whole-file
+    And a function in "utils.ts"
+    When deciding whether to include the function
+    Then the function is included
+
+  Scenario: Function with changed lines inside it is included
+    Given a filter where "service.ts" has changes on lines 10 to 15
+    And a function in "service.ts" spanning lines 5 to 20
+    When deciding whether to include the function
+    Then the function is included
+
+  Scenario: Function with no changed lines inside it is excluded
+    Given a filter where "service.ts" has changes on lines 10 to 15
+    And a function in "service.ts" spanning lines 50 to 60
+    When deciding whether to include the function
+    Then the function is excluded
+
+  Scenario: File with only deletion hunks excludes all functions
+    Given a filter where "cleanup.ts" has an empty change list
+    And a function in "cleanup.ts" spanning lines 1 to 30
+    When deciding whether to include the function
+    Then the function is excluded

--- a/tests/domain/filtering.test.ts
+++ b/tests/domain/filtering.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { spansOverlap, shouldInclude } from "../../src/domain/filtering.js";
+import type {
+  SourceSpan,
+  FunctionFilter,
+  FunctionIdentity,
+} from "../../src/domain/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function span(start: number, end: number): SourceSpan {
+  return { startLine: start, startColumn: 0, endLine: end, endColumn: 0 };
+}
+
+function identity(filePath: string, s: SourceSpan): FunctionIdentity {
+  return { filePath, qualifiedName: "fn", span: s };
+}
+
+function filter(
+  entries: [string, ReadonlyArray<SourceSpan> | null][],
+): FunctionFilter {
+  return {
+    description: "test filter",
+    changedFiles: new Map(entries),
+  };
+}
+
+// ── spansOverlap ─────────────────────────────────────────────────────
+
+describe("spansOverlap", () => {
+  it("returns true when spans share lines", () => {
+    expect(spansOverlap(span(5, 15), span(10, 20))).toBe(true);
+  });
+
+  it("returns false when spans are separated", () => {
+    expect(spansOverlap(span(5, 10), span(15, 20))).toBe(false);
+  });
+
+  it("returns false for adjacent spans under half-open convention", () => {
+    // [5, 10) and [10, 15) — endLine 10 is exclusive, so no overlap
+    expect(spansOverlap(span(5, 10), span(10, 15))).toBe(false);
+  });
+
+  it("returns false for reverse-adjacent spans under half-open convention", () => {
+    // [10, 15) and [5, 10) — tests the other boundary direction
+    expect(spansOverlap(span(10, 15), span(5, 10))).toBe(false);
+  });
+
+  it("returns true for single-line change inside a function", () => {
+    expect(spansOverlap(span(1, 50), span(25, 26))).toBe(true);
+  });
+});
+
+// ── shouldInclude ────────────────────────────────────────────────────
+
+describe("shouldInclude", () => {
+  it("excludes functions in files not in the filter", () => {
+    const f = filter([["other.ts", null]]);
+    expect(shouldInclude(f, identity("utils.ts", span(1, 10)))).toBe(false);
+  });
+
+  it("includes all functions when file maps to null (whole-file)", () => {
+    const f = filter([["utils.ts", null]]);
+    expect(shouldInclude(f, identity("utils.ts", span(1, 10)))).toBe(true);
+  });
+
+  it("includes functions with changed lines inside them", () => {
+    const f = filter([["service.ts", [span(10, 15)]]]);
+    expect(shouldInclude(f, identity("service.ts", span(5, 20)))).toBe(true);
+  });
+
+  it("excludes functions with no changed lines inside them", () => {
+    const f = filter([["service.ts", [span(10, 15)]]]);
+    expect(shouldInclude(f, identity("service.ts", span(50, 60)))).toBe(false);
+  });
+
+  it("excludes functions when file has empty change list (deletion-only)", () => {
+    const f = filter([["cleanup.ts", []]]);
+    expect(shouldInclude(f, identity("cleanup.ts", span(1, 30)))).toBe(false);
+  });
+
+  it("includes function when it overlaps one of multiple changed spans", () => {
+    // File has changes at lines 10-15 and 50-55; function spans 45-60
+    const f = filter([["service.ts", [span(10, 15), span(50, 55)]]]);
+    expect(shouldInclude(f, identity("service.ts", span(45, 60)))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Line-level filtering**: Upgrades `--changed-since` from file-level to function-level granularity. Only functions containing added/modified lines are CRAP-scored, reducing noise in large diffs.
- **Domain filtering**: Pure `shouldInclude()` and `spansOverlap()` functions in `domain/filtering.ts` using half-open `[startLine, endLine)` spans.
- **Unified diff parsing**: Rewrites `cli/diff.ts` to parse `git diff --unified=0` hunk headers, producing `FunctionFilter` with line-level spans. New files map to `null` (whole-file).
- **Safety warning**: Emits `filter-excluded-all` warning when the filter excludes all discovered functions, preventing silent CI false-passes.
- **Architecture validation**: Adds dependency-cruiser with 6 rules enforcing hexagonal architecture. Extracts `AnalyzeDeps` to `core/deps.ts` to break circular dependency.
- **Error handling**: Improved `defaultExec` catch block with explicit ENOENT detection and proper error propagation.

## Architecture Decisions

- **ADR-5**: CLI owns git-to-filter conversion; core only knows `FunctionFilter` (Shape C)
- **ADR-6**: `FunctionFilter` uses `null` for whole-file changes (new files)
- **ADR-7**: `AnalyzeDeps` extracted to `core/deps.ts` to break circular imports
- **ADR-8**: `filter-excluded-all` warning prevents silent CI false-passes

## Test Plan

- [x] 19 BDD scenarios across 3 feature files (domain, cli, core)
- [x] 1361 tests passing (12 new tests added)
- [x] 100% mutation score on domain filtering code (Stryker)
- [x] 0 dependency-cruiser violations across 45 modules
- [x] CRAP analysis: all changed modules ≤ 8 threshold
- [x] Typecheck, lint, and build all clean

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)