### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to crap4ts are documented here. This project follows [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] — Unreleased
+## [1.0.0] — 2026-03-22
 
 ### Breaking Changes
 
@@ -12,7 +12,7 @@ All notable changes to crap4ts are documented here. This project follows [Semant
 
 - JSON/API consumers should treat `result.functions` as the canonical scored result set. `result.summary`, `result.passed`, and threshold outcomes are derived from that set.
 - `result.unmatched` remains diagnostic mismatch detail and should not be added on top of summary totals.
-- GitHub Action users should update `uses: breezy-bays-labs/crap4ts@v0` to `uses: breezy-bays-labs/crap4ts@v1` when adopting the v1 release line.
+- GitHub Action users should pin to `uses: breezy-bays-labs/crap4ts@v1` on the stable major release line.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ const result = await parseCoverageFile("./coverage/coverage-final.json");
 
 - Functions with complexity but no matching coverage entry are now scored at 0% coverage and included in `result.functions`, `result.summary`, and threshold decisions.
 - Treat `result.functions` as the canonical scored result set. `result.unmatched` remains diagnostic mismatch detail and should not be added on top of summary totals.
-- GitHub Action users should update `uses: breezy-bays-labs/crap4ts@v0` to `uses: breezy-bays-labs/crap4ts@v1` once the v1 tag is published.
+- GitHub Action users should pin to `uses: breezy-bays-labs/crap4ts@v1` on the stable major release line.
 
 ## Coverage Format Support
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,8 @@ node dist/cli.js --summary
    gh release create v<version> --title "v<version>" --notes-file <notes-file>
    ```
 
+   For the first npm publish of `crap4ts`, this is also the step that makes the README npm badge resolve instead of showing `package not found`.
+
 5. After the publish workflow succeeds, move or create the floating major Action tag (`v1`) to the same release commit:
 
    ```bash
@@ -66,6 +68,7 @@ node dist/cli.js --summary
 ## Post-Release Verification
 
 - Verify the npm package page shows the new version.
+- Verify the README npm badge resolves from npm instead of showing `package not found`.
 - Verify `npx crap4ts@<version> --help` works in a clean shell.
 - Verify the GitHub Action resolves from `breezy-bays-labs/crap4ts@v1`.
 - Verify the README examples still match the released surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crap4ts",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crap4ts",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap4ts",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "CRAP score analyzer for TypeScript — find complex, under-tested functions",
   "type": "module",
   "bin": {

--- a/tests/cli/integration.test.ts
+++ b/tests/cli/integration.test.ts
@@ -124,7 +124,7 @@ describe("output formats", () => {
 
   it("--version shows the correct version string", async () => {
     const { stdout } = await runCli(["--version"]);
-    expect(stdout.trim()).toBe("0.3.0");
+    expect(stdout.trim()).toBe(PACKAGE_VERSION.version);
   });
 
   it("markdown output contains content", async () => {


### PR DESCRIPTION
## Summary
- bump the package metadata from 0.3.0 to 1.0.0
- finalize the 1.0.0 changelog entry and clean the v1 action guidance
- document that the first npm publish is what makes the README npm badge resolve
- make the CLI version integration test derive from package.json so future releases do not break it

## Verification
- npm run typecheck
- npm run lint
- npm test
- NPM_CONFIG_CACHE=/tmp/crap4ts-npm-cache npm pack --dry-run

## Post-merge release steps
1. Merge this PR to main.
2. Create and push tag `v1.0.0` from the merge commit.
3. Create the GitHub release for `v1.0.0` using the changelog notes.
4. Wait for `.github/workflows/publish.yml` to publish `crap4ts@1.0.0` to npm.
5. Move the floating `v1` tag to the same release commit after publish succeeds.
6. Verify the README npm badge resolves and `npx crap4ts@1.0.0 --help` works.
