### PR TITLE
chore: maintenance-mode banner — announce crap4ts@2 rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPLv3%2B-blue.svg)](./LICENSE)
 [![Node >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
-> **Maintenance mode.** `crap4ts@1.x` is in maintenance mode (security and critical bug fixes only). A `crap4ts@2` is being rebuilt as a thin Rust-backed adapter on top of the language-agnostic `crap-core` library, distributed via napi-rs. Track progress at [breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs) (repo was renamed from `crap4rs`). For working CRAP analysis on TypeScript today, `crap4ts@1.x` is still the answer.
+> **Maintenance mode.** `crap4ts@1.x` is in maintenance mode (security and critical bug fixes only). `crap4ts@2` is being rebuilt as a thin Rust-backed adapter on top of the language-agnostic `crap-core` library, distributed via napi-rs. Track progress at [breezy-bays-labs/crap4rs](https://github.com/breezy-bays-labs/crap4rs) (the repo will be renamed to `crap-rs` at the v0.5.0 release). For working CRAP analysis on TypeScript today, `crap4ts@1.x` is still the answer.
 
 CRAP score analyzer for TypeScript — find functions that are too complex and too poorly tested.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPLv3%2B-blue.svg)](./LICENSE)
 [![Node >= 18](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
+> **Maintenance mode.** `crap4ts@1.x` is in maintenance mode (security and critical bug fixes only). A `crap4ts@2` is being rebuilt as a thin Rust-backed adapter on top of the language-agnostic `crap-core` library, distributed via napi-rs. Track progress at [breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs) (repo was renamed from `crap4rs`). For working CRAP analysis on TypeScript today, `crap4ts@1.x` is still the answer.
+
 CRAP score analyzer for TypeScript — find functions that are too complex and too poorly tested.
 
 Unlike hosted services, crap4ts runs locally and in CI with zero configuration, combining cyclomatic complexity *and* test coverage into a single actionable score.


### PR DESCRIPTION
## Summary

- `crap4ts@1.x` is in maintenance mode — security + critical bug fixes only.
- `crap4ts@2` is being rebuilt as a Rust-backed napi-rs adapter on top of the new `crap-core` library being extracted from `crap4rs` (soon renamed to `crap-rs`).

## Context

The Rust analyzer side (`breezy-bays-labs/crap4rs`) has surpassed `crap4ts@1.x` in feature surface and reliability. Rather than keep two divergent codebases, the plan is to retire the standalone TS implementation and rebuild `crap4ts@2` as a thin shell over `crap-core`, distributed via napi-rs.

- Tracking repo: [breezy-bays-labs/crap4rs](https://github.com/breezy-bays-labs/crap4rs) (will be renamed to `crap-rs` at v0.5.0)
- Migration pipeline: `crap-rs/20260509-monorepo-migration`
- The `crap4ts@2` alpha shell crate lands in the same monorepo migration, but the real TypeScript walker (oxc) ships in a follow-up pipeline. Until then, `crap4ts@1.x` remains the way to analyze TS projects.

## Test plan

- [x] README banner renders correctly in GitHub preview
- [ ] Companion GH release (`v1.x-maintenance-announcement`) cut after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintenance mode notice for v1.x, indicating it will receive only security and critical fixes
  * Highlighted availability of v2.x as the recommended upgrade path with enhanced performance
  * Updated repository reference information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap4ts/pull/38)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->